### PR TITLE
Add `Peer::connect` utility function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v0.2.0:
+  * Rename `into_transport_default()` to `into_default_transport()`.
+
 v0.1.4:
   * Regenerate `README.md` from library documentation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 v0.2.0:
   * Rename `into_transport_default()` to `into_default_transport()`.
+  * Add `Peer::connect` function.
 
 v0.1.4:
   * Regenerate `README.md` from library documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,27 @@
-# v0.2.0 - unreleased
-  * Rename `into_transport_default()` to `into_default_transport()`.
-  * Add `Peer::connect` function.
+# Changelog
 
-# v0.1.4 - 2020-10-04
-  * Regenerate `README.md` from library documentation.
+## v0.2.0 - unreleased
+### Added
+- Added `Peer::connect` function.
 
-# v0.1.3 - 2020-10-13
-  * Fix link of `docs.rs` badge in README.
+### Changed
+- Renamed `into_transport_default()` to `into_default_transport()`.
 
-# v0.1.2 - 2020-10-13
-  * Fix links to documentation in README.
+## v0.1.4 - 2020-10-04
+### Fixed
+- Regenerate `README.md` from library documentation.
 
-# v0.1.1 - 2020-10-13
-  * Build `docs.rs` documentation with all transports enabled.
+## v0.1.3 - 2020-10-13
+### Fixed
+- Fix link of `docs.rs` badge in README.
 
-# v0.1.0 - 2020-10-13
-  * Initial release.
+## v0.1.2 - 2020-10-13
+### Fixed
+- Fix links to documentation in README.
+
+## v0.1.1 - 2020-10-13
+### Fixed
+- Build `docs.rs` documentation with all transports enabled.
+
+## v0.1.0 - 2020-10-13
+- Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,18 @@
-v0.2.0:
+# v0.2.0 - unreleased
   * Rename `into_transport_default()` to `into_default_transport()`.
   * Add `Peer::connect` function.
 
-v0.1.4:
+# v0.1.4 - 2020-10-04
   * Regenerate `README.md` from library documentation.
 
-v0.1.3:
+# v0.1.3 - 2020-10-13
   * Fix link of `docs.rs` badge in README.
 
-v0.1.2:
+# v0.1.2 - 2020-10-13
   * Fix links to documentation in README.
 
-v0.1.1:
+# v0.1.1 - 2020-10-13
   * Build `docs.rs` documentation with all transports enabled.
 
-v0.1.0:
+# v0.1.0 - 2020-10-13
   * Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tokio-seqpacket = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 assert2 = "0.3.2"
-tokio = { version = "0.2.0", features = ["rt-core", "uds", "macros"] }
+tokio = { version = "0.2.0", features = ["dns", "macros", "rt-core", "uds"] }
 fizyr-rpc = { path = ".", features = ["unix-seqpacket", "unix-stream", "tcp"] }
 structopt = "0.3.18"
 memfd = "0.3.0"

--- a/README.tpl
+++ b/README.tpl
@@ -6,8 +6,8 @@
 {{readme}}
 
 [`Peer`]: https://docs.rs/fizyr-rpc/latest/fizyr_rpc/struct.Peer.html
+[`Peer::connect()`]: https://docs.rs/fizyr-rpc/latest/fizyr_rpc/struct.Peer.html#method.connect
 [`Peer::run()`]: https://docs.rs/fizyr-rpc/latest/fizyr_rpc/struct.Peer.html#method.run
-[`Peer::spawn()`]: https://docs.rs/fizyr-rpc/latest/fizyr_rpc/struct.Peer.html#method.spawn
 [`PeerHandle`]: https://docs.rs/fizyr-rpc/latest/fizyr_rpc/struct.PeerHandle.html
 [`PeerReadHandle`]: https://docs.rs/fizyr-rpc/latest/fizyr_rpc/struct.PeerReadHandle.html
 [`PeerWriteHandle`]: https://docs.rs/fizyr-rpc/latest/fizyr_rpc/struct.PeerWriteHandle.html

--- a/examples/unix-seqpacket-client.rs
+++ b/examples/unix-seqpacket-client.rs
@@ -1,9 +1,7 @@
-use fizyr_rpc::IntoTransport;
-use fizyr_rpc::Peer;
+use fizyr_rpc::UnixSeqpacketPeer;
 
 use std::path::PathBuf;
 use structopt::StructOpt;
-use tokio_seqpacket::UnixSeqpacket;
 
 #[derive(StructOpt)]
 #[structopt(setting = structopt::clap::AppSettings::ColoredHelp)]
@@ -22,13 +20,9 @@ async fn main() {
 }
 
 async fn do_main(options: &Options) -> Result<(), String> {
-	// Connect a socket to the server.
-	let socket = UnixSeqpacket::connect(&options.socket)
-		.await
+	// Connect to a remote server.
+	let mut peer = UnixSeqpacketPeer::connect(&options.socket, Default::default()).await
 		.map_err(|e| format!("failed to connect to {}: {}", options.socket.display(), e))?;
-
-	// Wrap the socket in a transport, and create a peer from the transport.
-	let mut peer = Peer::spawn(socket.into_transport_default());
 
 	// Send a request to the remote peer.
 	let mut request = peer

--- a/examples/unix-stream-client.rs
+++ b/examples/unix-stream-client.rs
@@ -1,9 +1,7 @@
-use fizyr_rpc::IntoTransport;
-use fizyr_rpc::Peer;
+use fizyr_rpc::UnixStreamPeer;
 
 use std::path::PathBuf;
 use structopt::StructOpt;
-use tokio::net::UnixStream;
 
 #[derive(StructOpt)]
 #[structopt(setting = structopt::clap::AppSettings::ColoredHelp)]
@@ -22,13 +20,9 @@ async fn main() {
 }
 
 async fn do_main(options: &Options) -> Result<(), String> {
-	// Connect a socket to the server.
-	let socket = UnixStream::connect(&options.socket)
-		.await
+	// Connect to a remote server.
+	let mut peer = UnixStreamPeer::connect(&options.socket, Default::default()).await
 		.map_err(|e| format!("failed to connect to {}: {}", options.socket.display(), e))?;
-
-	// Wrap the socket in a transport, and create a peer from the transport.
-	let mut peer = Peer::spawn(socket.into_transport_default());
 
 	// Send a request to the remote peer.
 	let mut request = peer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ pub use request::SentRequest;
 pub use request_tracker::RequestTracker;
 pub use server::Server;
 pub use server::ServerListener;
+pub use transport::Connect;
 pub use transport::IntoTransport;
 pub use transport::Transport;
 pub use transport::TransportReadHalf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,10 @@
 //! to allow moving the handles into different tasks.
 //! The write handle can also be cloned and used in multiple tasks.
 //!
-//! To obtain a [`PeerHandle`], you must first create a [`Peer`] object.
-//! The [`Peer`] object is responsible for reading and writing messages with the peer,
-//! but you can't use it for sending or receiving messages directly.
-//! Instead, you must ensure that the [`Peer::run()`] future is being polled.
-//! The easiest way to do that is by calling [`Peer::spawn()`],
-//! which will run the future in a background task and returns a [`PeerHandle`].
+//! To obtain a [`PeerHandle`], you can call [`Peer::connect()`].
+//! This will connect to a remote server and spawn a background task to read and write messages over the connection.
+//! If you need full control over tasks, you can instead create a [`Peer`] object
+//! and call [`Peer::run()`] manually.
 //!
 //! ## Server
 //!
@@ -55,6 +53,31 @@
 //! * `tcp`: for the [`TcpTransport`]
 //! * `unix-stream`: for the [`UnixStreamTransport`]
 //! * `unix-seqpacket`: for the [`UnixSeqpacketTransport`]
+//!
+//! # Example
+//!
+//! ```no_run
+//! use fizyr_rpc::{TcpPeer, StreamConfig};
+//!
+//! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut peer = TcpPeer::connect("localhost:1337", StreamConfig::default()).await?;
+//! let mut request = peer.send_request(1, &b"Hello World!"[..]).await?;
+//!
+//! loop {
+//!     let message = request.next_message().await?;
+//!     let body = std::str::from_utf8(&message.body)?;
+//!
+//!     if message.header.message_type.is_responder_update() {
+//!         eprintln!("Received update: {}", body);
+//!     } else if message.header.message_type.is_response() {
+//!         eprintln!("Received response: {}", body);
+//!         break;
+//!     }
+//! }
+//!
+//! # Ok(())
+//! # }
+//! ```
 
 #![warn(missing_docs)]
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -12,6 +12,7 @@ mod impl_unix_stream {
 
 	impl crate::Transport for StreamTransport<tokio::net::UnixStream> {
 		type Body = StreamBody;
+		type Config = StreamConfig;
 		type ReadHalf = ReadHalfType;
 		type WriteHalf = WriteHalfType;
 
@@ -56,6 +57,7 @@ mod impl_tcp {
 
 	impl crate::Transport for StreamTransport<tokio::net::TcpStream> {
 		type Body = StreamBody;
+		type Config = StreamConfig;
 		type ReadHalf = ReadHalfType;
 		type WriteHalf = WriteHalfType;
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -63,7 +63,7 @@ pub trait IntoTransport: Sized + Send {
 	fn into_transport(self, config: Self::Config) -> Self::Transport;
 
 	/// Create a transport from `self` using the default configuration.
-	fn into_transport_default(self) -> Self::Transport
+	fn into_default_transport(self) -> Self::Transport
 	where
 		Self::Config: Default,
 	{

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -13,6 +13,9 @@ pub trait Transport: Send + 'static {
 	/// The body type for the messages.
 	type Body: crate::Body;
 
+	/// The configuration type for the transport.
+	type Config: Clone + Default + Send + Sync + 'static;
+
 	/// The type of the read half of the transport.
 	type ReadHalf: for<'a> ReadHalfType<'a, Body = Self::Body>;
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -74,6 +74,15 @@ pub trait IntoTransport: Sized + Send {
 	}
 }
 
+/// Trait for connecting transports to a remote address.
+pub trait Connect<'a, Address: 'a>: Sized + Transport {
+	/// The type of the future returned by `Self::connect`.
+	type Future: Future<Output = std::io::Result<Self>>;
+
+	/// Create a new transport connected to a remote address.
+	fn connect(address: Address, config: Self::Config) -> Self::Future;
+}
+
 /// Trait for the read half of a transport type.
 pub trait TransportReadHalf: Send + Unpin {
 	/// The body type for messages transferred over the transport.

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -12,6 +12,7 @@ mod impl_unix_seqpacket {
 
 	impl crate::Transport for UnixTransport<tokio_seqpacket::UnixSeqpacket> {
 		type Body = UnixBody;
+		type Config = UnixConfig;
 		type ReadHalf = ReadHalfType;
 		type WriteHalf = WriteHalfType;
 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -68,8 +68,8 @@ mod test {
 	async fn test_unix_transport() {
 		let_assert!(Ok((socket_a, socket_b)) = UnixSeqpacket::pair());
 
-		let mut transport_a = socket_a.into_transport_default();
-		let mut transport_b = socket_b.into_transport_default();
+		let mut transport_a = socket_a.into_default_transport();
+		let mut transport_b = socket_b.into_default_transport();
 
 		use crate::{Transport, TransportReadHalf, TransportWriteHalf};
 		let (mut read_a, mut write_a) = transport_a.split();

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -8,6 +8,8 @@ pub use transport::{UnixReadHalf, UnixTransport, UnixWriteHalf};
 
 #[cfg(feature = "unix-seqpacket")]
 mod impl_unix_seqpacket {
+	use std::future::Future;
+	use std::pin::Pin;
 	use super::*;
 
 	impl crate::Transport for UnixTransport<tokio_seqpacket::UnixSeqpacket> {
@@ -24,7 +26,6 @@ mod impl_unix_seqpacket {
 		}
 	}
 
-	#[cfg(feature = "unix-seqpacket")]
 	impl crate::IntoTransport for tokio_seqpacket::UnixSeqpacket {
 		type Body = UnixBody;
 		type Config = UnixConfig;
@@ -32,6 +33,20 @@ mod impl_unix_seqpacket {
 
 		fn into_transport(self, config: Self::Config) -> Self::Transport {
 			UnixTransport::new(self, config)
+		}
+	}
+
+	impl<'a, Address> crate::Connect<'a, Address> for UnixTransport<tokio_seqpacket::UnixSeqpacket>
+	where
+		Address: AsRef<std::path::Path> + 'a,
+	{
+		type Future = Pin<Box<dyn Future<Output = std::io::Result<Self>> + 'a>>;
+
+		fn connect(address: Address, config: Self::Config) -> Self::Future {
+			Box::pin(async move {
+				let socket = tokio_seqpacket::UnixSeqpacket::connect(address).await?;
+				Ok(Self::new(socket, config))
+			})
 		}
 	}
 


### PR DESCRIPTION
This PR adds `Peer::connect()` as a short-hand for creating a new socket, wrapping it in a transport and spawning a peer.

You can take a look at the examples for how it simplifies usage.

Also updated the library documentation and added an example.

It also includes a breaking change: it renames `into_transport_default()` to `into_default_transport()`. This will be properly indicated in the version number with the next release.