### PR TITLE
Use Vec<u8> for data instead of Box<[u8]>.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added `Server::bind` function.
 
 ### Changed
+- Use `Vec<u8>` for body data instead of `Box<[u8]>`.
+
+### Changed
 - Renamed `into_transport_default()` to `into_default_transport()`.
 
 ## v0.1.4 - 2020-10-04

--- a/src/stream/body.rs
+++ b/src/stream/body.rs
@@ -2,12 +2,12 @@
 #[derive(Debug, Clone)]
 pub struct StreamBody {
 	/// The message data.
-	pub data: Box<[u8]>,
+	pub data: Vec<u8>,
 }
 
 impl StreamBody {
 	/// Create a new stream body.
-	fn new(data: Box<[u8]>) -> Self {
+	fn new(data: Vec<u8>) -> Self {
 		Self { data }
 	}
 }
@@ -20,7 +20,7 @@ impl crate::Body for StreamBody {
 
 impl<T> From<T> for StreamBody
 where
-	Box<[u8]>: From<T>,
+	Vec<u8>: From<T>,
 {
 	fn from(other: T) -> Self {
 		Self { data: other.into() }

--- a/src/unix/body.rs
+++ b/src/unix/body.rs
@@ -6,7 +6,7 @@ use filedesc::FileDesc;
 /// and a list of file descriptors to attach.
 pub struct UnixBody {
 	/// The contents for the datagram.
-	pub data: Box<[u8]>,
+	pub data: Vec<u8>,
 
 	/// The file descriptors to attach.
 	pub fds: Vec<FileDesc>,
@@ -16,7 +16,7 @@ impl UnixBody {
 	/// Create a new unix body with datagram contents and file descriptors to attach.
 	pub fn new<Data, FileDescs>(data: Data, fds: FileDescs) -> Self
 	where
-		Box<[u8]>: From<Data>,
+		Vec<u8>: From<Data>,
 		Vec<FileDesc>: From<FileDescs>,
 	{
 		Self {
@@ -32,8 +32,8 @@ impl crate::Body for UnixBody {
 	}
 }
 
-impl From<Box<[u8]>> for UnixBody {
-	fn from(other: Box<[u8]>) -> Self {
+impl From<Vec<u8>> for UnixBody {
+	fn from(other: Vec<u8>) -> Self {
 		Self {
 			data: other,
 			fds: Vec::new(),
@@ -47,15 +47,15 @@ impl<'a> From<&'a [u8]> for UnixBody {
 	}
 }
 
-impl From<Vec<u8>> for UnixBody {
-	fn from(other: Vec<u8>) -> Self {
-		other.into_boxed_slice().into()
+impl From<Box<[u8]>> for UnixBody {
+	fn from(other: Box<[u8]>) -> Self {
+		Vec::from(other).into()
 	}
 }
 
 impl<Data, FileDescs> From<(Data, FileDescs)> for UnixBody
 where
-	Box<[u8]>: From<Data>,
+	Vec<u8>: From<Data>,
 	Vec<FileDesc>: From<FileDescs>,
 {
 	fn from(other: (Data, FileDescs)) -> Self {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -113,7 +113,7 @@ mod test {
 			assert!(let Ok(()) = write_a.write_msg(&MessageHeader::request(i * 2, 10), &body).await);
 			let_assert!(Ok(message) = read_b.read_msg().await);
 			assert!(message.header == MessageHeader::request(i * 2, 10));
-			assert!(message.body.data.as_ref() == b"Hello peer_b!");
+			assert!(message.body.data == b"Hello peer_b!");
 			assert!(message.body.fds.len() == 2);
 			let_assert!(Ok(blob_0) = read_blob(&message.body.fds[0]));
 			let_assert!(Ok(blob_1) = read_blob(&message.body.fds[1]));
@@ -123,7 +123,7 @@ mod test {
 			assert!(let Ok(()) = write_b.write_msg(&MessageHeader::request(i * 2 + 1, 11), &b"Hello peer_a!"[..].into()).await);
 			let_assert!(Ok(message) = read_a.read_msg().await);
 			assert!(message.header == MessageHeader::request(i * 2 + 1, 11));
-			assert!(message.body.data.as_ref() == b"Hello peer_a!");
+			assert!(message.body.data == b"Hello peer_a!");
 		}
 	}
 


### PR DESCRIPTION
Although `Vec` has an unnecessary additional field to distinguish capacity from length, converting a `Vec` to `Box` is not a zero-cost
operation. It truncates the capacity to the length before converting. Going the other way is cheap: it simply fills in the capacity and length as the same value.

So `Vec` is more optimal in cases where data actually came from a vector, while it hardly matters for the other way around.