### PR TITLE
Update to tokio 0.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.3.0 - unreleased
 ### Changed
 - Update to tokio 0.3.
+- Remove meaningless addresses from Accept implementation for Unix sockets.
 
 ## v0.2.1 - 2020-09-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0 - unreleased
+### Changed
+- Update to tokio 0.3.
+
 ## v0.2.1 - 2020-09-03
 ### Fixed
 - Fixed link in README.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,20 +18,20 @@ categories = ["asynchronous", "network-programming"]
 edition = "2018"
 
 [features]
-tcp = ["tokio/tcp"]
-unix-stream = ["tokio/uds"]
+tcp = ["tokio/net"]
+unix-stream = ["tokio/net"]
 unix-seqpacket = ["filedesc", "tokio-seqpacket"]
 
 [dependencies]
 byteorder = "1.3.4"
 filedesc = { version = "0.3.0", optional = true }
 thiserror = "1.0.20"
-tokio = { version = "0.2.0", features = ["rt-core", "sync", "io-util", "stream"] }
-tokio-seqpacket = { version = "0.2.1", optional = true }
+tokio = { version = "0.3.3", features = ["rt", "sync"] }
+tokio-seqpacket = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 assert2 = "0.3.2"
-tokio = { version = "0.2.0", features = ["dns", "macros", "rt-core", "uds"] }
+tokio = { version = "0.3.3", features = ["macros"] }
 fizyr-rpc = { path = ".", features = ["unix-seqpacket", "unix-stream", "tcp"] }
 structopt = "0.3.18"
 memfd = "0.3.0"

--- a/examples/unix-seqpacket-client.rs
+++ b/examples/unix-seqpacket-client.rs
@@ -11,7 +11,7 @@ struct Options {
 	socket: PathBuf,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
 	if let Err(e) = do_main(&Options::from_args()).await {
 		eprintln!("Error: {}", e);

--- a/examples/unix-seqpacket-server.rs
+++ b/examples/unix-seqpacket-server.rs
@@ -10,7 +10,7 @@ struct Options {
 	socket: PathBuf,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
 	if let Err(e) = do_main(&Options::from_args()).await {
 		eprintln!("Error: {}", e);

--- a/examples/unix-stream-client.rs
+++ b/examples/unix-stream-client.rs
@@ -11,7 +11,7 @@ struct Options {
 	socket: PathBuf,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
 	if let Err(e) = do_main(&Options::from_args()).await {
 		eprintln!("Error: {}", e);

--- a/examples/unix-stream-server.rs
+++ b/examples/unix-stream-server.rs
@@ -10,7 +10,7 @@ struct Options {
 	socket: PathBuf,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
 	if let Err(e) = do_main(&Options::from_args()).await {
 		eprintln!("Error: {}", e);

--- a/src/transport/stream/transport.rs
+++ b/src/transport/stream/transport.rs
@@ -98,11 +98,12 @@ impl<W> StreamWriteHalf<W> {
 
 /// Wrapper around [`AsyncRead::poll_read`] that turns zero-sized reads into ConnectionAborted errors.
 fn poll_read<R: AsyncRead>(stream: Pin<&mut R>, context: &mut Context, buf: &mut [u8]) -> Poll<std::io::Result<usize>> {
-	match stream.poll_read(context, buf) {
-		Poll::Pending => Poll::Pending,
-		Poll::Ready(Ok(0)) => Poll::Ready(Err(std::io::ErrorKind::ConnectionAborted.into())),
-		Poll::Ready(Ok(n)) => Poll::Ready(Ok(n)),
-		Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+	let mut buf = tokio::io::ReadBuf::new(buf);
+	ready!(stream.poll_read(context, &mut buf))?;
+	if buf.filled().len() == 0 {
+		Poll::Ready(Err(std::io::ErrorKind::ConnectionAborted.into()))
+	} else {
+		Poll::Ready(Ok(buf.filled().len()))
 	}
 }
 

--- a/src/transport/stream/transport.rs
+++ b/src/transport/stream/transport.rs
@@ -100,7 +100,7 @@ impl<W> StreamWriteHalf<W> {
 fn poll_read<R: AsyncRead>(stream: Pin<&mut R>, context: &mut Context, buf: &mut [u8]) -> Poll<std::io::Result<usize>> {
 	let mut buf = tokio::io::ReadBuf::new(buf);
 	ready!(stream.poll_read(context, &mut buf))?;
-	if buf.filled().len() == 0 {
+	if buf.filled().is_empty() {
 		Poll::Ready(Err(std::io::ErrorKind::ConnectionAborted.into()))
 	} else {
 		Poll::Ready(Ok(buf.filled().len()))

--- a/src/util/accept.rs
+++ b/src/util/accept.rs
@@ -61,7 +61,7 @@ impl Listener for tokio::net::TcpListener {
 
 #[cfg(feature = "unix-stream")]
 impl Listener for tokio::net::UnixListener {
-	type Address = std::os::unix::net::SocketAddr;
+	type Address = tokio::net::unix::SocketAddr;
 	type Connection = tokio::net::UnixStream;
 
 	fn poll_accept(self: Pin<&mut Self>, context: &mut Context) -> Poll<std::io::Result<(Self::Connection, Self::Address)>> {

--- a/src/util/accept.rs
+++ b/src/util/accept.rs
@@ -61,23 +61,27 @@ impl Listener for tokio::net::TcpListener {
 
 #[cfg(feature = "unix-stream")]
 impl Listener for tokio::net::UnixListener {
-	type Address = tokio::net::unix::SocketAddr;
+	// Unix socket connections don't have meaningfull addresses for connected peers.
+	type Address = ();
 	type Connection = tokio::net::UnixStream;
 
 	fn poll_accept(self: Pin<&mut Self>, context: &mut Context) -> Poll<std::io::Result<(Self::Connection, Self::Address)>> {
 		let accept = tokio::net::UnixListener::accept(self.get_mut());
 		tokio::pin!(accept);
-		accept.poll(context)
+		let (socket, _address) = ready!(accept.poll(context))?;
+		Poll::Ready(Ok((socket, ())))
 	}
 }
 
 #[cfg(feature = "unix-seqpacket")]
 impl Listener for tokio_seqpacket::UnixSeqpacketListener {
-	type Address = std::os::unix::net::SocketAddr;
+	// Unix socket connections don't have meaningfull addresses for connected peers.
+	type Address = ();
 	type Connection = tokio_seqpacket::UnixSeqpacket;
 
 	fn poll_accept(self: Pin<&mut Self>, context: &mut Context) -> Poll<std::io::Result<(Self::Connection, Self::Address)>> {
-		tokio_seqpacket::UnixSeqpacketListener::poll_accept(self.get_mut(), context)
+		let (socket, _address) = ready!(self.get_mut().poll_accept( context))?;
+		Poll::Ready(Ok((socket, ())))
 	}
 }
 


### PR DESCRIPTION
This PR updates to tokio 0.3.

Additionally, the `Accept` implementations for unix sockets no longer return the peer address. The address is always empty, since connected unix sockets are anonymous anyway. Additionally, the server doesn't forward the address to the handler currently, so nobody should notice.

/edit: The reason for removing the address is mainly that tokio 0.3 made it impossible to report the address with the same type as used by tokio. By throwing the address away we can use the same type again :)