### PR TITLE
Implement argument parsing for new `interface!{}` macro.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ memfile = "0.2.0"
 
 [package.metadata.docs.rs]
 features = ["tcp", "unix-stream", "unix-seqpacket"]
+
+[workspace]
+members = ["derive", "derive-macros"]

--- a/derive-macros/Cargo.toml
+++ b/derive-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fizyr-rpc-derive-macros"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc_macro = true
+
+[dependencies]
+syn = { version = "1.0.72", default-features = false, features = ["derive", "parsing", "printing", "proc-macro", "extra-traits"] }
+proc-macro2 = "1.0.26"
+quote = "1.0.9"

--- a/derive-macros/src/interface.rs
+++ b/derive-macros/src/interface.rs
@@ -1,0 +1,361 @@
+pub fn generate_interface(tokens: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+	let raw: raw::InterfaceDefinition = match syn::parse2(tokens) {
+		Ok(x) => x,
+		Err(e) => return e.into_compile_error(),
+	};
+
+	let mut errors = Vec::new();
+	let interface = cooked::InterfaceDefinition::from_raw(&mut errors, raw);
+	if !errors.is_empty() {
+		let mut error_tokens = proc_macro2::TokenStream::new();
+		for error in errors {
+			error_tokens.extend(error.into_compile_error());
+		}
+		return error_tokens;
+	}
+
+	eprintln!("{:#?}", interface);
+	proc_macro2::TokenStream::new()
+}
+
+/// Second stage parsing types.
+///
+/// These types never contain invalid data.
+/// However, parsing them from their [`raw`] counterparts
+/// always gives a cooked type and a list of errors.
+/// If the list of errors is non-empty,
+/// input data that caused the errors was discarded from the cooked type.
+///
+/// The cooked type can still be used for code generation to minimize the impact
+/// on code using the generated type, but the errors MUST be emitted too.
+mod cooked {
+	use crate::util::{parse_doc_attr_contents, parse_eq_attr_contents, WithSpan};
+
+	#[derive(Debug)]
+	pub struct InterfaceDefinition {
+		pub name: syn::Ident,
+		pub doc: Vec<WithSpan<String>>,
+		pub services: Vec<ServiceDefinition>,
+		pub request_enum: Option<syn::Ident>,
+		pub client_struct: Option<syn::Ident>,
+		pub server_struct: Option<syn::Ident>,
+	}
+
+	#[derive(Debug)]
+	pub struct InterfaceAttributes {
+		doc: Vec<WithSpan<String>>,
+		request_enum: Option<syn::Ident>,
+		client_struct: Option<syn::Ident>,
+		server_struct: Option<syn::Ident>,
+	}
+
+	#[derive(Debug)]
+	pub struct ServiceDefinition {
+		pub service_id: WithSpan<i32>,
+		pub name: syn::Ident,
+		pub doc: Vec<WithSpan<String>>,
+		pub request_type: Option<Box<syn::Type>>,
+		pub response_type: Option<Box<syn::Type>>,
+		pub request_updates: Vec<UpdateDefinition>,
+		pub response_updates: Vec<UpdateDefinition>,
+	}
+
+	#[derive(Debug)]
+	struct ServiceAttributes {
+		service_id: WithSpan<i32>,
+		doc: Vec<WithSpan<String>>,
+		request_updates: Vec<UpdateDefinition>,
+		response_updates: Vec<UpdateDefinition>,
+	}
+
+	#[derive(Debug)]
+	pub struct UpdateDefinition {
+		pub service_id: WithSpan<i32>,
+		pub body_type: Box<syn::Type>,
+	}
+
+	impl InterfaceDefinition {
+		pub fn from_raw(errors: &mut Vec<syn::Error>, raw: super::raw::InterfaceDefinition) -> Self {
+			let attrs = InterfaceAttributes::from_raw(errors, raw.attrs);
+			let services = raw.services.into_iter().map(|raw| ServiceDefinition::from_raw(errors, raw)).collect();
+			Self {
+				name: raw.name,
+				doc: attrs.doc,
+				services,
+				request_enum: attrs.request_enum,
+				client_struct: attrs.client_struct,
+				server_struct: attrs.server_struct,
+			}
+		}
+	}
+
+	impl InterfaceAttributes {
+		fn from_raw(errors: &mut Vec<syn::Error>, attrs: Vec<syn::Attribute>) -> Self {
+			let mut doc = Vec::new();
+			let mut request_enum = None;
+			let mut client_struct = None;
+			let mut server_struct = None;
+
+			for attr in attrs {
+				if attr.path.is_ident("doc") {
+					match parse_doc_attr_contents(attr.tokens) {
+						Ok(x) => doc.push(x),
+						Err(e) => errors.push(e),
+					}
+				} else if attr.path.is_ident("request_enum") {
+					match parse_eq_attr_contents::<syn::Ident>(attr.tokens) {
+						Err(e) => errors.push(e),
+						Ok(ident) => {
+							if request_enum.is_some() {
+								errors.push(syn::Error::new_spanned(
+									&attr.path,
+									format!("duplicate `{}' attribute", attr.path.segments[0].ident),
+								))
+							} else {
+								request_enum = Some(ident);
+							}
+						},
+					}
+				} else if attr.path.is_ident("client_struct") {
+					match parse_eq_attr_contents::<syn::Ident>(attr.tokens) {
+						Err(e) => errors.push(e),
+						Ok(ident) => {
+							if client_struct.is_some() {
+								errors.push(syn::Error::new_spanned(
+									&attr.path,
+									format!("duplicate `{}' attribute", attr.path.segments[0].ident),
+								))
+							} else {
+								client_struct = Some(ident);
+							}
+						},
+					}
+				} else if attr.path.is_ident("server_struct") {
+					match parse_eq_attr_contents::<syn::Ident>(attr.tokens) {
+						Err(e) => errors.push(e),
+						Ok(ident) => {
+							if server_struct.is_some() {
+								errors.push(syn::Error::new_spanned(
+									&attr.path,
+									format!("duplicate `{}' attribute", attr.path.segments[0].ident),
+								))
+							} else {
+								server_struct = Some(ident);
+							}
+						},
+					}
+				} else {
+					errors.push(syn::Error::new_spanned(attr.path, "unknown attribute"));
+				}
+			}
+
+			Self {
+				doc,
+				request_enum,
+				client_struct,
+				server_struct,
+			}
+		}
+	}
+
+	impl ServiceDefinition {
+		fn from_raw(errors: &mut Vec<syn::Error>, raw: super::raw::ServiceDefinition) -> Self {
+			let attrs = ServiceAttributes::from_raw(errors, raw.name.span(), raw.attrs);
+			Self {
+				service_id: attrs.service_id,
+				name: raw.name,
+				doc: attrs.doc,
+				request_type: raw.request_type.ty,
+				response_type: raw.response_type.map(|x| x.ty),
+				request_updates: attrs.request_updates,
+				response_updates: attrs.response_updates,
+			}
+		}
+	}
+
+	impl ServiceAttributes {
+		fn from_raw(errors: &mut Vec<syn::Error>, name_span: proc_macro2::Span, attrs: Vec<syn::Attribute>) -> Self {
+			let mut service_id = None;
+			let mut doc = Vec::new();
+			let mut request_updates: Vec<UpdateDefinition> = Vec::new();
+			let mut response_updates: Vec<UpdateDefinition> = Vec::new();
+
+			for attr in attrs {
+				if attr.path.is_ident("service_id") {
+					if service_id.is_some() {
+						errors.push(syn::Error::new_spanned(&attr.path, "duplicate `service_id' attribute"));
+					}
+					match parse_i32_attr_contents(attr.tokens) {
+						Err(e) => errors.push(e),
+						Ok(id) => {
+							if service_id.is_none() {
+								service_id = Some(id);
+							}
+						},
+					}
+				} else if attr.path.is_ident("doc") {
+					match parse_doc_attr_contents(attr.tokens) {
+						Err(e) => errors.push(e),
+						Ok(x) => doc.push(x),
+					}
+				} else if attr.path.is_ident("request_update") {
+					match parse_update_attr(attr.tokens) {
+						Err(e) => errors.push(e),
+						Ok(update) => {
+							if request_updates.iter().any(|x| x.service_id.value == update.service_id.value) {
+								errors.push(syn::Error::new(update.service_id.span, "duplicate service ID for request update"));
+							} else {
+								request_updates.push(update)
+							}
+						},
+					}
+				} else if attr.path.is_ident("response_update") {
+					match parse_update_attr(attr.tokens) {
+						Err(e) => errors.push(e),
+						Ok(update) => {
+							if response_updates.iter().any(|x| x.service_id.value == update.service_id.value) {
+								errors.push(syn::Error::new(update.service_id.span, "duplicate service ID for response update"));
+							} else {
+								response_updates.push(update)
+							}
+						},
+					}
+				} else {
+					errors.push(syn::Error::new_spanned(attr.path, "unknown attribute"));
+				}
+			}
+
+			let service_id = service_id.unwrap_or_else(|| {
+				errors.push(syn::Error::new(name_span, "missing `#[service_id = i32]' attribute"));
+				WithSpan::new(proc_macro2::Span::call_site(), 0)
+			});
+
+			Self {
+				service_id,
+				doc,
+				request_updates,
+				response_updates,
+			}
+		}
+	}
+
+	fn parse_i32_attr_contents(tokens: proc_macro2::TokenStream) -> syn::Result<WithSpan<i32>> {
+		let int: syn::LitInt = parse_eq_attr_contents(tokens)?;
+		Ok(WithSpan::new(int.span(), int.base10_parse()?))
+	}
+
+	fn parse_update_attr(tokens: proc_macro2::TokenStream) -> syn::Result<UpdateDefinition> {
+		struct UpdateAttr {
+			_paren_token: syn::token::Paren,
+			service_id: syn::LitInt,
+			_comma_token: syn::token::Comma,
+			body_type: Box<syn::Type>,
+		}
+
+		impl syn::parse::Parse for UpdateAttr {
+			#[allow(clippy::eval_order_dependence)]
+			fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+				let contents;
+				Ok(Self {
+					_paren_token: syn::parenthesized!(contents in input),
+					service_id: contents.parse()?,
+					_comma_token: contents.parse()?,
+					body_type: contents.parse()?,
+				})
+			}
+		}
+
+		let parsed: UpdateAttr = syn::parse2(tokens)?;
+		let service_id = WithSpan::new(parsed.service_id.span(), parsed.service_id.base10_parse()?);
+		let body_type = parsed.body_type;
+		Ok(UpdateDefinition { service_id, body_type })
+	}
+}
+
+/// First stage parsing types.
+///
+/// The types in this modules still contain potentially invalid data.
+/// We want to fully parse this raw form before continuing to more detailed error checking.
+mod raw {
+	#[derive(Debug)]
+	pub struct InterfaceDefinition {
+		pub attrs: Vec<syn::Attribute>,
+		pub visibility: syn::Visibility,
+		pub name: syn::Ident,
+		pub _brace: syn::token::Brace,
+		pub services: Vec<ServiceDefinition>,
+	}
+
+	#[derive(Debug)]
+	pub struct ServiceDefinition {
+		pub attrs: Vec<syn::Attribute>,
+		pub _fn_token: syn::token::Fn,
+		pub name: syn::Ident,
+		pub request_type: RequestType,
+		pub response_type: Option<ResponseType>,
+		pub _semi_token: syn::token::Semi,
+	}
+
+	#[derive(Debug)]
+	pub struct RequestType {
+		pub paren_token: syn::token::Paren,
+		pub ty: Option<Box<syn::Type>>,
+	}
+
+	#[derive(Debug)]
+	pub struct ResponseType {
+		pub arrow: syn::token::RArrow,
+		pub ty: Box<syn::Type>,
+	}
+
+	impl syn::parse::Parse for InterfaceDefinition {
+		#[allow(clippy::eval_order_dependence)]
+		fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+			let services;
+			Ok(Self {
+				attrs: input.call(syn::Attribute::parse_outer)?,
+				visibility: input.parse()?,
+				name: input.parse()?,
+				_brace: syn::braced!(services in input),
+				services: crate::util::parse_repeated(&services)?,
+			})
+		}
+	}
+
+	impl syn::parse::Parse for ServiceDefinition {
+		#[allow(clippy::eval_order_dependence)]
+		fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+			Ok(Self {
+				attrs: input.call(syn::Attribute::parse_outer)?,
+				_fn_token: input.parse()?,
+				name: input.parse()?,
+				request_type: input.parse()?,
+				response_type: parse_response_type(input)?,
+				_semi_token: input.parse()?,
+			})
+		}
+	}
+
+	impl syn::parse::Parse for RequestType {
+		#[allow(clippy::eval_order_dependence)]
+		fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+			let request_type;
+			Ok(Self {
+				paren_token: syn::parenthesized!(request_type in input),
+				ty: if request_type.is_empty() { None } else { Some(request_type.parse()?) },
+			})
+		}
+	}
+
+	#[allow(clippy::eval_order_dependence)]
+	fn parse_response_type(input: syn::parse::ParseStream) -> syn::Result<Option<ResponseType>> {
+		if input.peek(syn::token::RArrow) {
+			Ok(Some(ResponseType {
+				arrow: input.parse()?,
+				ty: input.parse()?,
+			}))
+		} else {
+			Ok(None)
+		}
+	}
+}

--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -1,0 +1,8 @@
+mod interface;
+mod util;
+
+/// Define an RPC interface.
+#[proc_macro]
+pub fn interface(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	interface::generate_interface(tokens.into()).into()
+}

--- a/derive-macros/src/util.rs
+++ b/derive-macros/src/util.rs
@@ -1,0 +1,64 @@
+use proc_macro2::{Span, TokenStream};
+use syn::parse::{Parse, ParseStream};
+
+/// A span and a value.
+///
+/// Mainly used to keep spans around for generating errors later on.
+#[derive(Debug)]
+pub struct WithSpan<T> {
+	pub span: Span,
+	pub value: T,
+}
+
+impl<T> WithSpan<T> {
+	/// Create a new `WithSpan` from a [`Span`] and a value.
+	pub fn new(span: Span, value: T) -> Self {
+		Self { span, value }
+	}
+}
+
+impl<T> syn::spanned::Spanned for WithSpan<T> {
+	fn span(&self) -> Span {
+		self.span
+	}
+}
+
+/// Keep parsing a type until the stream is depleted.
+///
+/// The type is parsed as-is without expecting any intermediate puncuation.
+pub fn parse_repeated<T: Parse>(input: ParseStream) -> syn::Result<Vec<T>> {
+	let mut result = Vec::new();
+	while !input.is_empty() {
+		result.push(input.parse()?);
+	}
+	Ok(result)
+}
+
+/// Helper struct to parse `= T` from a token stream.
+struct EqAttrContents<T> {
+	_eq_token: syn::token::Eq,
+	value: T,
+}
+
+impl<T: Parse> Parse for EqAttrContents<T> {
+	fn parse(input: ParseStream) -> syn::Result<Self> {
+		Ok(Self {
+			_eq_token: input.parse()?,
+			value: input.parse()?,
+		})
+	}
+}
+
+/// Parse the input tokens as `= T`.
+///
+/// This is useful for parsing `#[attr = value]` style attributes.
+pub fn parse_eq_attr_contents<T: Parse>(input: TokenStream) -> syn::Result<T> {
+	let parsed: EqAttrContents<T> = syn::parse2(input)?;
+	Ok(parsed.value)
+}
+
+/// Parse the string value of a doc attribute.
+pub fn parse_doc_attr_contents(input: TokenStream) -> syn::Result<WithSpan<String>> {
+	let doc: syn::LitStr = parse_eq_attr_contents(input)?;
+	Ok(WithSpan::new(doc.span(), doc.value()))
+}

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fizyr-rpc-derive"
+version = "0.1.0"
+edition = "2018"
+
+[features]
+logging = ["log"]
+
+[dependencies]
+fizyr-rpc = { version = "0.4.1", path = ".." }
+fizyr-rpc-derive-macros = { version = "0.1.0", path = "../derive-macros" }
+log = { version = "0.4.14", optional = true }
+serde = "1.0.125"

--- a/derive/src/error.rs
+++ b/derive/src/error.rs
@@ -1,0 +1,10 @@
+#[derive(Debug)]
+pub enum FromMessageError<ParseError> {
+	UnknownServiceId(UnknownServiceId),
+	Parse(ParseError),
+}
+
+#[derive(Debug)]
+pub struct UnknownServiceId {
+	pub service_id: i32,
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,0 +1,29 @@
+use fizyr_rpc::Message;
+pub use fizyr_rpc_derive_macros::interface;
+
+pub mod error;
+use error::FromMessageError;
+
+pub trait FromMessageBody<Body>: Sized {
+	type Error;
+
+	fn from_message_body(body: &Body) -> Result<Self, Self::Error>;
+}
+
+pub trait ToMessageBody<Body> {
+	type Error;
+
+	fn to_message_body(&self) -> Result<Body, Self::Error>;
+}
+
+pub trait FromMessage<Body>: Sized {
+	type ParseError;
+
+	fn from_message(message: &Message<Body>) -> Result<Self, FromMessageError<Self::ParseError>>;
+}
+
+pub trait ToMessage<Body>: Sized {
+	type Error;
+
+	fn to_message(&self) -> Result<Self, Self::Error>;
+}

--- a/derive/tests/derive.rs
+++ b/derive/tests/derive.rs
@@ -1,0 +1,12 @@
+use fizyr_rpc_derive::interface;
+
+interface!(
+	pub Camera {
+		#[service_id = 0x12]
+		fn ping();
+
+		#[service_id = 1]
+		#[response_update(1001, RecordState)]
+		fn record_image(RecordImageRequest) -> CameraData;
+	}
+);


### PR DESCRIPTION
This PR implements initial argument parsing for a new `interface! {}` macro which will eventually generate some boilerplate to make using `fizyr-rpc` easier.

As I see it now (but this may be subject to change), the macro will generate three types:

* `${Name}Client`: a client struct with an async function per service.
* `${Name}Request`: an enum with one variant per service in the interface, where each variant contains the parsed request body.
* `${Name}Server`: a server struct that helps you handle incoming requests.

I don't have much more details to share yet, because there are still some open questions, for example:
* How will we limit update types that you can send or receive based on the interface definition?
* How will we decouple the generated code from the binary serialization format? I don't want to hardcode `fizyr-binary-v1`.
* How much work will be done by generic helper types/functions and how much will we just duplicate when generating code? I'm leaning towards duplicating code because it generally leads to easier to understand error messages when you use it wrong. It also helps to discover things in documentation or by looking at auto-completion suggestions. Also, async functions in traits don't exist yet, which might complicate matters too.

The macro will need a lot more documentation, but I intend to do that once the design is stable. In the mean time, this is what it currently parses:
```rust
use fizyr_rpc_derive::interface;

interface!(
	pub Camera {
		#[service_id = 0]
		fn ping();

		#[service_id = 1]
		#[response_update(1001, RecordState)]
		fn record_image(RecordImageRequest) -> CameraData;
	}
);
```

Note: This PR merges into `derive`, not in `main`, since there is a lot more work to be done after this.