### PR TITLE
Remove the *received* request when sending a response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main
+### Fixed
+- Fixed bug where a sent request was untracked once a response to a received request was sent.
+
 ## v0.4.1 - 2021-04-25
 ### Fixed
 - Fixed reading messages with empty body with the `StreamTransport`.

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -311,7 +311,7 @@ where
 	async fn send_raw_message(&mut self, command: crate::peer::SendRawMessage<W::Body>) -> LoopFlow {
 		// Remove tracked received requests when we send a response.
 		if command.message.header.message_type.is_response() {
-			let _: Result<_, _> = self.request_tracker.remove_sent_request(command.message.header.request_id);
+			let _: Result<_, _> = self.request_tracker.remove_received_request(command.message.header.request_id);
 		}
 
 		// TODO: replace SendRawMessage with specific command for different message types.


### PR DESCRIPTION
The code was erroneously removing the *sent* request when a response was sent. That caused two bugs:

* A received request with the same ID would no longer receive updates.
* The ID of the sent request was reserved for too long, meaning a new  request with the same ID was wrongly refused.