### PR TITLE
Update syntax for `interace! { ... }` macro.

### DIFF
--- a/macros-tests/src/lib.rs
+++ b/macros-tests/src/lib.rs
@@ -1,23 +1,31 @@
 fizyr_rpc::interface! {
-	pub camera {
-		#[service_id = 0]
+	interface camera {
 		/// Ping the server.
-		fn ping();
+		service 0 ping: () -> (),
 
-		#[service_id = 1]
 		/// Record an image.
-		fn record() {
-			#[service_id = 10]
-			#[request_update]
-			nevermind: (),
-
-			#[service_id = 11]
-			#[response_update]
-			state: RecordState,
+		service 1 record: () -> () {
+			request_update 10 cancel: CancelReason,
+			response_update 11 state: RecordState,
+			response_update 12 image: Image,
 		}
 	}
 }
 
 pub enum RecordState {
+	Recording,
+	Processing,
+	Done,
 }
 
+pub enum CancelReason {
+	BecauseISaidSo,
+	SomeDoofusObscuredTheCameraView,
+}
+
+pub struct Image {
+	pub width: u32,
+	pub height: u32,
+	pub format: u32,
+	pub data: Vec<u8>,
+}

--- a/macros/src/interface/parse.rs
+++ b/macros/src/interface/parse.rs
@@ -9,19 +9,16 @@
 /// The cooked type can still be used for code generation to minimize the impact
 /// on code using the generated type, but the errors MUST be emitted too.
 pub mod cooked {
-	use crate::util::{parse_doc_attr_contents, parse_eq_attr_contents, WithSpan};
+	use crate::util::{parse_doc_attr_contents, WithSpan};
 	use proc_macro2::Span;
+	use super::raw;
 
 	#[derive(Debug)]
 	pub struct InterfaceDefinition {
 		name: syn::Ident,
 		doc: Vec<WithSpan<String>>,
 		services: Vec<ServiceDefinition>,
-	}
-
-	#[derive(Debug)]
-	pub struct InterfaceAttributes {
-		doc: Vec<WithSpan<String>>,
+		streams: Vec<StreamDefinition>,
 	}
 
 	#[derive(Debug)]
@@ -29,21 +26,15 @@ pub mod cooked {
 		service_id: WithSpan<i32>,
 		name: syn::Ident,
 		doc: Vec<WithSpan<String>>,
-		request_type: Option<Box<syn::Type>>,
-		response_type: Option<Box<syn::Type>>,
+		request_type: Box<syn::Type>,
+		response_type: Box<syn::Type>,
 		request_updates: Vec<UpdateDefinition>,
 		response_updates: Vec<UpdateDefinition>,
 	}
 
 	#[derive(Debug)]
-	struct ServiceAttributes {
-		service_id: WithSpan<i32>,
-		doc: Vec<WithSpan<String>>,
-	}
-
-	#[derive(Debug)]
 	pub struct UpdateDefinition {
-		service_id: Option<WithSpan<i32>>,
+		service_id: WithSpan<i32>,
 		name: syn::Ident,
 		doc: Vec<WithSpan<String>>,
 		body_type: Box<syn::Type>,
@@ -51,15 +42,20 @@ pub mod cooked {
 
 	#[derive(Debug)]
 	pub struct UpdateAttributes {
-		service_id: Option<WithSpan<i32>>,
-		kind: Option<UpdateKind>,
 		doc: Vec<WithSpan<String>>,
 	}
 
 	#[derive(Debug)]
-	enum UpdateKind {
-		RequestUpdate,
-		ResponseUpdate,
+	pub struct StreamDefinition {
+		service_id: WithSpan<i32>,
+		name: syn::Ident,
+		doc: Vec<WithSpan<String>>,
+		body_type: Box<syn::Type>,
+	}
+
+	#[derive(Debug)]
+	struct DocOnlyAttributes {
+		doc: Vec<WithSpan<String>>,
 	}
 
 	impl InterfaceDefinition {
@@ -75,18 +71,161 @@ pub mod cooked {
 			&self.services
 		}
 
-		pub fn from_raw(errors: &mut Vec<syn::Error>, raw: super::raw::InterfaceDefinition) -> Self {
-			let attrs = InterfaceAttributes::from_raw(errors, raw.attrs);
-			let services = raw.services.into_iter().map(|raw| ServiceDefinition::from_raw(errors, raw)).collect();
+		#[allow(dead_code)]
+		pub fn streams(&self) -> &[StreamDefinition] {
+			&self.streams
+		}
+
+		pub fn from_raw(errors: &mut Vec<syn::Error>, raw: raw::InterfaceDefinition) -> Self {
+			let attrs = DocOnlyAttributes::from_raw(errors, raw.attrs);
+			let mut services = Vec::new();
+			let mut streams = Vec::new();
+			for item in raw.items {
+				match item {
+					raw::InterfaceItem::Service(raw) => services.push(ServiceDefinition::from_raw(errors, raw)),
+					raw::InterfaceItem::Stream(raw) => streams.push(StreamDefinition::from_raw(errors, raw)),
+				}
+			}
 			Self {
 				name: raw.name,
 				doc: attrs.doc,
 				services,
+				streams,
 			}
 		}
 	}
 
-	impl InterfaceAttributes {
+	impl ServiceDefinition {
+		pub fn service_id(&self) -> WithSpan<i32> {
+			self.service_id.clone()
+		}
+
+		pub fn name(&self) -> &syn::Ident {
+			&self.name
+		}
+
+		pub fn doc(&self) -> &[WithSpan<String>] {
+			&self.doc
+		}
+
+		pub fn request_type(&self) -> &syn::Type {
+			self.request_type.as_ref()
+		}
+
+		pub fn response_type(&self) -> &syn::Type {
+			self.response_type.as_ref()
+		}
+
+		pub fn request_updates(&self) -> &[UpdateDefinition] {
+			&self.request_updates
+		}
+
+		pub fn response_updates(&self) -> &[UpdateDefinition] {
+			&self.response_updates
+		}
+
+		fn from_raw(errors: &mut Vec<syn::Error>, raw: raw::ServiceDefinition) -> Self {
+			let attrs = DocOnlyAttributes::from_raw(errors, raw.attrs);
+			let mut request_updates = Vec::new();
+			let mut response_updates = Vec::new();
+			if let raw::MaybeServiceBody::Body(body, _) = raw.body {
+				for update in body.updates {
+					match UpdateDefinition::from_raw(errors, update) {
+						(raw::UpdateKind::RequestUpdate(_), update) => request_updates.push(update),
+						(raw::UpdateKind::ResponseUpdate(_), update) => response_updates.push(update),
+					}
+				}
+			}
+
+			for (i, a) in request_updates.iter().enumerate() {
+				for b in &request_updates[i + 1..] {
+					if a.service_id.value == b.service_id.value {
+						errors.push(syn::Error::new(b.service_id.span, "duplicate service ID"));
+					}
+				}
+			}
+
+			for (i, a) in response_updates.iter().enumerate() {
+				for b in &response_updates[i + 1..] {
+					if a.service_id.value == b.service_id.value {
+						errors.push(syn::Error::new(b.service_id.span, "duplicate service ID"));
+					}
+				}
+			}
+
+			Self {
+				service_id: parse_i32(errors, raw.service_id),
+				name: raw.name,
+				doc: attrs.doc,
+				request_type: raw.request_type,
+				response_type: raw.response_type,
+				request_updates,
+				response_updates,
+			}
+		}
+	}
+
+	impl UpdateDefinition {
+		pub fn service_id(&self) -> &WithSpan<i32> {
+			&self.service_id
+		}
+
+		pub fn name(&self) -> &syn::Ident {
+			&self.name
+		}
+
+		pub fn doc(&self) -> &[WithSpan<String>] {
+			&self.doc
+		}
+
+		pub fn body_type(&self) -> &syn::Type {
+			&self.body_type
+		}
+
+		fn from_raw(errors: &mut Vec<syn::Error>, raw: raw::UpdateDefinition) -> (raw::UpdateKind, Self) {
+			let attrs = DocOnlyAttributes::from_raw(errors, raw.attrs);
+
+			(raw.kind, Self {
+				service_id: parse_i32(errors, raw.service_id),
+				name: raw.name,
+				doc: attrs.doc,
+				body_type: raw.body_type,
+			})
+		}
+	}
+
+	#[allow(dead_code)]
+	impl StreamDefinition {
+		pub fn service_id(&self) -> &WithSpan<i32> {
+			&self.service_id
+		}
+
+		pub fn name(&self) -> &syn::Ident {
+			&self.name
+		}
+
+		pub fn doc(&self) -> &[WithSpan<String>] {
+			&self.doc
+		}
+
+		pub fn body_type(&self) -> &syn::Type {
+			self.body_type.as_ref()
+		}
+
+		fn from_raw(errors: &mut Vec<syn::Error>, raw: raw::StreamDefinition) -> Self {
+			let attrs = DocOnlyAttributes::from_raw(errors, raw.attrs);
+
+			Self {
+				service_id: parse_i32(errors, raw.service_id),
+				name: raw.name,
+				doc: attrs.doc,
+				body_type: raw.body_type,
+			}
+		}
+	}
+
+
+	impl DocOnlyAttributes {
 		fn from_raw(errors: &mut Vec<syn::Error>, attrs: Vec<syn::Attribute>) -> Self {
 			let mut doc = Vec::new();
 
@@ -105,217 +244,14 @@ pub mod cooked {
 		}
 	}
 
-	impl ServiceDefinition {
-		pub fn service_id(&self) -> WithSpan<i32> {
-			self.service_id.clone()
-		}
-
-		pub fn name(&self) -> &syn::Ident {
-			&self.name
-		}
-
-		pub fn doc(&self) -> &[WithSpan<String>] {
-			&self.doc
-		}
-
-		pub fn request_type(&self) -> Option<&syn::Type> {
-			self.request_type.as_deref()
-		}
-
-		pub fn response_type(&self) -> Option<&syn::Type> {
-			self.response_type.as_deref()
-		}
-
-		pub fn request_updates(&self) -> &[UpdateDefinition] {
-			&self.request_updates
-		}
-
-		pub fn response_updates(&self) -> &[UpdateDefinition] {
-			&self.response_updates
-		}
-
-		fn from_raw(errors: &mut Vec<syn::Error>, raw: super::raw::ServiceDefinition) -> Self {
-			let attrs = ServiceAttributes::from_raw(errors, raw.name.span(), raw.attrs);
-			let mut request_updates = Vec::new();
-			let mut response_updates = Vec::new();
-			if let super::raw::MaybeServiceBody::Body(body) = raw.body {
-				for update in body.updates {
-					match UpdateDefinition::from_raw(errors, update) {
-						(Some(UpdateKind::RequestUpdate), update) => request_updates.push(update),
-						(Some(UpdateKind::ResponseUpdate), update) => response_updates.push(update),
-						(None, _) => (),
-					}
-				}
-			}
-
-			for (i, a) in request_updates.iter().enumerate() {
-				if let Some(id_a) = &a.service_id {
-					for b in &request_updates[i + 1..] {
-						if let Some(id_b) = &b.service_id {
-							if id_b.value == id_a.value {
-								errors.push(syn::Error::new(id_b.span, "duplicate service ID"));
-							}
-						}
-					}
-				} else {
-					errors.push(syn::Error::new_spanned(&a.name, "missing `#[service_id = ...]' attribute"));
-				}
-			}
-
-			for (i, a) in response_updates.iter().enumerate() {
-				if let Some(id_a) = &a.service_id {
-					for b in &response_updates[i + 1..] {
-						if let Some(id_b) = &b.service_id {
-							if id_b.value == id_a.value {
-								errors.push(syn::Error::new(id_b.span, "duplicate service ID"));
-							}
-						}
-					}
-				} else {
-					errors.push(syn::Error::new_spanned(&a.name, "missing `#[service_id = ...]' attribute"));
-				}
-			}
-
-			Self {
-				service_id: attrs.service_id,
-				name: raw.name,
-				doc: attrs.doc,
-				request_type: raw.request_type.ty,
-				response_type: raw.response_type.map(|x| x.ty),
-				request_updates,
-				response_updates,
+	fn parse_i32(errors: &mut Vec<syn::Error>, literal: syn::LitInt) -> WithSpan<i32> {
+		match literal.base10_parse() {
+			Ok(x) => WithSpan::new(literal.span(), x),
+			Err(e) => {
+				errors.push(e);
+				WithSpan::new(Span::call_site(), 0)
 			}
 		}
-	}
-
-	impl ServiceAttributes {
-		fn from_raw(errors: &mut Vec<syn::Error>, name_span: proc_macro2::Span, attrs: Vec<syn::Attribute>) -> Self {
-			let mut service_id = None;
-			let mut doc = Vec::new();
-
-			for attr in attrs {
-				if attr.path.is_ident("service_id") {
-					if service_id.is_some() {
-						errors.push(syn::Error::new_spanned(&attr.path, "duplicate `service_id' attribute"));
-					}
-					match parse_i32_attr_contents(attr.tokens) {
-						Err(e) => errors.push(e),
-						Ok(id) => {
-							if service_id.is_none() {
-								service_id = Some(id);
-							}
-						},
-					}
-				} else if attr.path.is_ident("doc") {
-					match parse_doc_attr_contents(attr.tokens) {
-						Err(e) => errors.push(e),
-						Ok(x) => doc.push(x),
-					}
-				} else {
-					errors.push(syn::Error::new_spanned(attr.path, "unknown attribute"));
-				}
-			}
-
-			let service_id = service_id.unwrap_or_else(|| {
-				errors.push(syn::Error::new(name_span, "missing `#[service_id = i32]' attribute"));
-				WithSpan::new(proc_macro2::Span::call_site(), 0)
-			});
-
-			Self {
-				service_id,
-				doc,
-			}
-		}
-	}
-
-	impl UpdateDefinition {
-		pub fn service_id(&self) -> WithSpan<i32> {
-			self.service_id.clone().unwrap_or_else(|| WithSpan::new(Span::call_site(), 0))
-		}
-
-		pub fn name(&self) -> &syn::Ident {
-			&self.name
-		}
-
-		pub fn doc(&self) -> &[WithSpan<String>] {
-			&self.doc
-		}
-
-		pub fn body_type(&self) -> &syn::Type {
-			&self.body_type
-		}
-
-		fn from_raw(errors: &mut Vec<syn::Error>, raw: super::raw::UpdateDefinition) -> (Option<UpdateKind>, Self) {
-			let name = raw.name;
-			let attrs = UpdateAttributes::from_raw(errors, raw.attrs);
-
-			(attrs.kind, Self {
-				service_id: attrs.service_id,
-				name,
-				doc: attrs.doc,
-				body_type: raw.body_type,
-			})
-		}
-	}
-
-	impl UpdateAttributes {
-		fn from_raw(errors: &mut Vec<syn::Error>, attrs: Vec<syn::Attribute>) -> Self {
-			let mut doc = Vec::new();
-			let mut kind = None;
-			let mut service_id = None;
-
-			for attr in attrs {
-				if attr.path.is_ident("doc") {
-					match parse_doc_attr_contents(attr.tokens) {
-						Ok(x) => doc.push(x),
-						Err(e) => errors.push(e),
-					}
-				} else if attr.path.is_ident("service_id") {
-					if service_id.is_some() {
-						errors.push(syn::Error::new_spanned(&attr.path, "duplicate `service_id' attribute"));
-					}
-					match parse_i32_attr_contents(attr.tokens) {
-						Err(e) => errors.push(e),
-						Ok(id) => {
-							if service_id.is_none() {
-								service_id = Some(id);
-							}
-						},
-					}
-				} else if attr.path.is_ident("request_update") {
-					if let Some(token) = attr.tokens.into_iter().next() {
-						errors.push(syn::Error::new_spanned(token, "unexpected token"));
-					}
-					if kind.is_some() {
-						errors.push(syn::Error::new_spanned(&attr.path, "duplicate update type attribute"));
-					} else {
-						kind = Some(UpdateKind::RequestUpdate);
-					}
-				} else if attr.path.is_ident("response_update") {
-					if let Some(token) = attr.tokens.into_iter().next() {
-						errors.push(syn::Error::new_spanned(token, "unexpected token"));
-					}
-					if kind.is_some() {
-						errors.push(syn::Error::new_spanned(&attr.path, "duplicate update type attribute"));
-					} else {
-						kind = Some(UpdateKind::ResponseUpdate);
-					}
-				} else {
-					errors.push(syn::Error::new_spanned(attr.path, "unknown attribute"));
-				}
-			}
-
-			Self {
-				service_id,
-				kind,
-				doc,
-			}
-		}
-	}
-
-	fn parse_i32_attr_contents(tokens: proc_macro2::TokenStream) -> syn::Result<WithSpan<i32>> {
-		let int: syn::LitInt = parse_eq_attr_contents(tokens)?;
-		Ok(WithSpan::new(int.span(), int.base10_parse()?))
 	}
 }
 
@@ -324,6 +260,14 @@ pub mod cooked {
 /// The types in this modules still contain potentially invalid data.
 /// We want to fully parse this raw form before continuing to more detailed error checking.
 pub mod raw {
+	mod keyword {
+		syn::custom_keyword!(interface);
+		syn::custom_keyword!(service);
+		syn::custom_keyword!(request_update);
+		syn::custom_keyword!(response_update);
+		syn::custom_keyword!(stream);
+	}
+
 	#[derive(Debug)]
 	pub struct InterfaceInput {
 		pub fizyr_rpc: syn::Ident,
@@ -334,26 +278,35 @@ pub mod raw {
 	#[derive(Debug)]
 	pub struct InterfaceDefinition {
 		pub attrs: Vec<syn::Attribute>,
-		pub visibility: syn::Visibility,
+		pub _interface: keyword::interface,
 		pub name: syn::Ident,
 		pub _brace_token: syn::token::Brace,
-		pub services: Vec<ServiceDefinition>,
+		pub items: Vec<InterfaceItem>,
+	}
+
+	#[derive(Debug)]
+	pub enum InterfaceItem {
+		Service(ServiceDefinition),
+		Stream(StreamDefinition),
 	}
 
 	#[derive(Debug)]
 	pub struct ServiceDefinition {
 		pub attrs: Vec<syn::Attribute>,
-		pub _fn_token: syn::token::Fn,
+		pub _service: keyword::service,
+		pub service_id: syn::LitInt,
 		pub name: syn::Ident,
-		pub request_type: RequestType,
-		pub response_type: Option<ResponseType>,
+		pub _colon: syn::token::Colon,
+		pub request_type: Box<syn::Type>,
+		pub _arrow: syn::Token![->],
+		pub response_type: Box<syn::Type>,
 		pub body: MaybeServiceBody,
 	}
 
 	#[derive(Debug)]
 	pub enum MaybeServiceBody {
-		NoBody(syn::token::Semi),
-		Body(ServiceBody),
+		NoBody(syn::token::Comma),
+		Body(ServiceBody, Option<syn::token::Comma>),
 	}
 
 	#[derive(Debug)]
@@ -365,21 +318,28 @@ pub mod raw {
 	#[derive(Debug)]
 	pub struct UpdateDefinition {
 		pub attrs: Vec<syn::Attribute>,
+		pub kind: UpdateKind,
+		pub service_id: syn::LitInt,
 		pub name: syn::Ident,
 		pub _colon_token: syn::token::Colon,
 		pub body_type: Box<syn::Type>,
 	}
 
 	#[derive(Debug)]
-	pub struct RequestType {
-		pub paren_token: syn::token::Paren,
-		pub ty: Option<Box<syn::Type>>,
+	pub enum UpdateKind {
+		RequestUpdate(keyword::request_update),
+		ResponseUpdate(keyword::response_update),
 	}
 
 	#[derive(Debug)]
-	pub struct ResponseType {
-		pub arrow: syn::token::RArrow,
-		pub ty: Box<syn::Type>,
+	pub struct StreamDefinition {
+		pub attrs: Vec<syn::Attribute>,
+		pub _stream: keyword::stream,
+		pub service_id: syn::LitInt,
+		pub name: syn::Ident,
+		pub _colon: syn::token::Colon,
+		pub body_type: Box<syn::Type>,
+		pub _comma: syn::token::Comma,
 	}
 
 	impl syn::parse::Parse for InterfaceInput {
@@ -395,51 +355,57 @@ pub mod raw {
 	impl syn::parse::Parse for InterfaceDefinition {
 		#[allow(clippy::eval_order_dependence)]
 		fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-			let services;
+			let body;
 			Ok(Self {
 				attrs: input.call(syn::Attribute::parse_outer)?,
-				visibility: input.parse()?,
+				_interface: input.parse()?,
 				name: input.parse()?,
-				_brace_token: syn::braced!(services in input),
-				services: services.call(crate::util::parse_repeated)?,
+				_brace_token: syn::braced!(body in input),
+				items: body.call(crate::util::parse_repeated)?,
 			})
 		}
 	}
 
-	impl syn::parse::Parse for ServiceDefinition {
-		#[allow(clippy::eval_order_dependence)]
+	impl syn::parse::Parse for InterfaceItem {
 		fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-			Ok(Self {
-				attrs: input.call(syn::Attribute::parse_outer)?,
-				_fn_token: input.parse()?,
-				name: input.parse()?,
-				request_type: input.parse()?,
-				response_type: parse_response_type(input)?,
-				body: input.parse()?,
-			})
-		}
-	}
-
-	impl syn::parse::Parse for RequestType {
-		#[allow(clippy::eval_order_dependence)]
-		fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-			let request_type;
-			Ok(Self {
-				paren_token: syn::parenthesized!(request_type in input),
-				ty: if request_type.is_empty() { None } else { Some(request_type.parse()?) },
-			})
+			let attrs = input.call(syn::Attribute::parse_outer)?;
+			if input.peek(keyword::service) {
+				Ok(InterfaceItem::Service(ServiceDefinition {
+					attrs,
+					_service: input.parse()?,
+					service_id: input.parse()?,
+					name: input.parse()?,
+					_colon: input.parse()?,
+					request_type: input.parse()?,
+					_arrow: input.parse()?,
+					response_type: input.parse()?,
+					body: input.parse()?,
+				}))
+			} else if input.peek(keyword::stream) {
+				Ok(InterfaceItem::Stream(StreamDefinition {
+					attrs,
+					_stream: input.parse()?,
+					service_id: input.parse()?,
+					name: input.parse()?,
+					_colon: input.parse()?,
+					body_type: input.parse()?,
+					_comma: input.parse()?,
+				}))
+			} else {
+				return Err(input.error("expected `service' or `stream'"));
+			}
 		}
 	}
 
 	impl syn::parse::Parse for MaybeServiceBody {
 		#[allow(clippy::eval_order_dependence)]
 		fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-			if input.peek(syn::token::Semi) {
+			if input.peek(syn::token::Comma) {
 				Ok(Self::NoBody(input.parse()?))
 			} else if input.peek(syn::token::Brace) {
-				Ok(Self::Body(input.parse()?))
+				Ok(Self::Body(input.parse()?, input.parse()?))
 			} else {
-				Err(input.error("expected semicolon or service body"))
+				Err(input.error("expected `,' or service body"))
 			}
 		}
 	}
@@ -456,10 +422,11 @@ pub mod raw {
 	}
 
 	impl syn::parse::Parse for UpdateDefinition {
-		#[allow(clippy::eval_order_dependence)]
 		fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
 			Ok(Self {
 				attrs: input.call(syn::Attribute::parse_outer)?,
+				kind: input.parse()?,
+				service_id: input.parse()?,
 				name: input.parse()?,
 				_colon_token: input.parse()?,
 				body_type: input.parse()?,
@@ -467,15 +434,15 @@ pub mod raw {
 		}
 	}
 
-	#[allow(clippy::eval_order_dependence)]
-	fn parse_response_type(input: syn::parse::ParseStream) -> syn::Result<Option<ResponseType>> {
-		if input.peek(syn::token::RArrow) {
-			Ok(Some(ResponseType {
-				arrow: input.parse()?,
-				ty: input.parse()?,
-			}))
-		} else {
-			Ok(None)
+	impl syn::parse::Parse for UpdateKind {
+		fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+			if input.peek(keyword::request_update) {
+				Ok(Self::RequestUpdate(input.parse()?))
+			} else if input.peek(keyword::response_update) {
+				Ok(Self::ResponseUpdate(input.parse()?))
+			} else {
+				Err(input.error("expected `request_update' or `response_update'"))
+			}
 		}
 	}
 }


### PR DESCRIPTION
The new syntax looks less like Rust code, but fits better for defining interfaces. Additionally, it more easily allows to add support for stream messages next to services.

A sample:
```rust
fizyr_rpc::interface! {
	interface camera {
		/// Ping the server.
		service 0 ping: () -> (),

		/// Record an image.
		service 1 record: () -> () {
			request_update 10 cancel: CancelReason,
			response_update 11 state: RecordState,
			response_update 12 image: Image,
		}
	}
}

fizyr_rpc::interface! {
	interface camera_state {
		/// Notification of the recording state of the camera.
		stream 100 record_state: RecordState,
	}
}

pub enum RecordState {
	Recording,
	Processing,
	Done,
}

pub enum CancelReason {
	BecauseISaidSo,
	SomeDoofusObscuredTheCameraView,
}

pub struct Image {
	pub width: u32,
	pub height: u32,
	pub format: u32,
	pub data: Vec<u8>,
}
```