### PR TITLE
Macros stream messages

### DIFF
--- a/macros-tests/src/lib.rs
+++ b/macros-tests/src/lib.rs
@@ -12,6 +12,18 @@ fizyr_rpc::interface! {
 	}
 }
 
+fizyr_rpc::interface! {
+	interface camera_state {
+		/// Notification of the record state of the camera.
+		stream 100 record_state: RecordState,
+	}
+}
+
+fizyr_rpc::interface! {
+	interface empty {
+	}
+}
+
 pub enum RecordState {
 	Recording,
 	Processing,

--- a/macros/src/interface/parse.rs
+++ b/macros/src/interface/parse.rs
@@ -71,7 +71,6 @@ pub mod cooked {
 			&self.services
 		}
 
-		#[allow(dead_code)]
 		pub fn streams(&self) -> &[StreamDefinition] {
 			&self.streams
 		}
@@ -194,7 +193,6 @@ pub mod cooked {
 		}
 	}
 
-	#[allow(dead_code)]
 	impl StreamDefinition {
 		pub fn service_id(&self) -> &WithSpan<i32> {
 			&self.service_id
@@ -392,7 +390,7 @@ pub mod raw {
 					_comma: input.parse()?,
 				}))
 			} else {
-				return Err(input.error("expected `service' or `stream'"));
+				Err(input.error("expected `service' or `stream'"))
 			}
 		}
 	}

--- a/src/error.rs
+++ b/src/error.rs
@@ -231,10 +231,10 @@ impl SendRequestError {
 	}
 }
 
-/// An error occurred while sending a request.
+/// An error occurred while sending an update or stream message.
 #[derive(Debug, Error)]
 #[error("{0}")]
-pub enum SendUpdateError {
+pub enum SendMessageError {
 	/// An I/O error occurred.
 	Io(#[from] std::io::Error),
 
@@ -245,7 +245,7 @@ pub enum SendUpdateError {
 	EncodeBody(Box<dyn std::error::Error + Send>),
 }
 
-impl SendUpdateError {
+impl SendMessageError {
 	/// Check if the error is an I/O error indicating that the connection was aborted by the remote peer.
 	pub fn is_connection_aborted(&self) -> bool {
 		if let Self::Io(e) = &self {
@@ -289,8 +289,8 @@ impl From<WriteMessageError> for SendRequestError {
 	}
 }
 
-// Allow a WriteMessageError to be converted to a SendUpdateError automatically.
-impl From<WriteMessageError> for SendUpdateError {
+// Allow a WriteMessageError to be converted to a SendMessageError automatically.
+impl From<WriteMessageError> for SendMessageError {
 	fn from(other: WriteMessageError) -> Self {
 		match other {
 			WriteMessageError::Io(e) => e.into(),

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -3,16 +3,6 @@ pub use fizyr_rpc_macros::interface as interface_impl;
 
 pub mod error;
 
-pub trait FromMessageBody<Body>: Sized {
-	fn from_message_body(body: &Body) -> Result<Self, Box<dyn std::error::Error + Send>>;
-}
-
-pub trait ToMessageBody<Body> {
-	type Error;
-
-	fn to_message_body(&self) -> Result<Body, Self::Error>;
-}
-
 pub trait Protocol {
 	type Body: crate::Body;
 	type Transport: crate::transport::Transport<Body = Self::Body>;

--- a/src/request.rs
+++ b/src/request.rs
@@ -118,7 +118,7 @@ impl<Body> SentRequest<Body> {
 	}
 
 	/// Send an update for the request to the remote peer.
-	pub async fn send_update(&self, service_id: i32, body: impl Into<Body>) -> Result<(), error::SendUpdateError> {
+	pub async fn send_update(&self, service_id: i32, body: impl Into<Body>) -> Result<(), error::SendMessageError> {
 		use crate::peer::SendRawMessage;
 		let body = body.into();
 		let (result_tx, result_rx) = oneshot::channel();


### PR DESCRIPTION
This PR adds code generation for sending/receiving typed stream messages.

Easiest way to review the result is to run `cargo doc --open` in de macros-test crate and compare to `macros-test/src/lib.rs`.

The PR also fixes compilation errors in the generated code when the services or streams of an interface are empty.