### PR TITLE
Simplify API for receiving updates on generated interfaces.

### DIFF
--- a/macros/src/interface/generate.rs
+++ b/macros/src/interface/generate.rs
@@ -284,7 +284,7 @@ fn generate_services(item_tokens: &mut TokenStream, client_impl_tokens: &mut Tok
 /// Generate the support types and function definitions for each service.
 fn generate_service(item_tokens: &mut TokenStream, client_impl_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, service: &ServiceDefinition) {
 	let service_name = service.name();
-	let service_doc = to_doc_attrs(&service.doc());
+	let service_doc = to_doc_attrs(service.doc());
 	let service_id = service.service_id();
 
 	let request_type = service.request_type();
@@ -318,7 +318,7 @@ fn generate_service(item_tokens: &mut TokenStream, client_impl_tokens: &mut Toke
 			}
 		})
 	} else {
-		generate_sent_request(&mut service_item_tokens, &fizyr_rpc, service);
+		generate_sent_request(&mut service_item_tokens, fizyr_rpc, service);
 		client_impl_tokens.extend(quote! {
 			#service_doc
 			pub async fn #service_name(&self, #request_param) -> Result<#service_name::SentRequest<F>, #fizyr_rpc::error::SendRequestError>
@@ -529,7 +529,7 @@ fn generate_streams(item_tokens: &mut TokenStream, client_impl_tokens: &mut Toke
 		generate_message_enum(
 			item_tokens,
 			fizyr_rpc,
-			&interface.streams(),
+			interface.streams(),
 			&syn::Ident::new("StreamMessage", Span::call_site()),
 			&format!("A stream message for the {} interface.", interface.name()),
 		);

--- a/macros/src/interface/parse.rs
+++ b/macros/src/interface/parse.rs
@@ -86,20 +86,41 @@ pub mod cooked {
 				}
 			}
 
-			for (i, a) in services.iter().enumerate() {
-				for b in &services[i + 1..] {
+			// Remove things with duplicate names, because they'll cause a lot more compile errors.
+			// Duplicate IDs we just generate though, because they don't cause duplicate type or functions name.
+			let mut remove_services = Vec::new();
+			let mut remove_streams = Vec::new();
+
+			for (a_i, a) in services.iter().enumerate() {
+				for (b_i, b) in services.iter().enumerate().skip(a_i + 1) {
 					if a.service_id.value == b.service_id.value {
 						errors.push(syn::Error::new(b.service_id.span, "duplicate service ID"));
+					}
+					if a.name() == b.name() {
+						errors.push(syn::Error::new(b.name().span(), "duplicate service name"));
+						remove_services.push(b_i);
 					}
 				}
 			}
 
-			for (i, a) in streams.iter().enumerate() {
-				for b in &streams[i + 1..] {
+			for (a_i, a) in streams.iter().enumerate() {
+				for (b_i, b) in streams.iter().enumerate().skip(a_i + 1) {
 					if a.service_id.value == b.service_id.value {
 						errors.push(syn::Error::new(b.service_id.span, "duplicate service ID"));
 					}
+					if a.name() == b.name() {
+						errors.push(syn::Error::new(b.name().span(), "duplicate stream name"));
+						remove_streams.push(b_i);
+					}
 				}
+			}
+
+			for i in remove_services.into_iter().rev() {
+				services.remove(i);
+			}
+
+			for i in remove_streams.into_iter().rev() {
+				streams.remove(i);
 			}
 
 			Self {
@@ -153,20 +174,41 @@ pub mod cooked {
 				}
 			}
 
-			for (i, a) in request_updates.iter().enumerate() {
-				for b in &request_updates[i + 1..] {
+			// Remove things with duplicate names, because they'll cause a lot more compile errors.
+			// Duplicate IDs we just generate though, because they don't cause duplicate type or functions name.
+			let mut remove_request_updates = Vec::new();
+			let mut remove_response_updates = Vec::new();
+
+			for (a_i, a) in request_updates.iter().enumerate() {
+				for (b_i, b) in request_updates.iter().enumerate().skip(a_i + 1) {
 					if a.service_id.value == b.service_id.value {
 						errors.push(syn::Error::new(b.service_id.span, "duplicate service ID"));
+					}
+					if a.name() == b.name() {
+						errors.push(syn::Error::new(b.name().span(), "duplicate request update name"));
+						remove_request_updates.push(b_i);
 					}
 				}
 			}
 
-			for (i, a) in response_updates.iter().enumerate() {
-				for b in &response_updates[i + 1..] {
+			for (a_i, a) in response_updates.iter().enumerate() {
+				for (b_i, b) in response_updates.iter().enumerate().skip(a_i + 1) {
 					if a.service_id.value == b.service_id.value {
 						errors.push(syn::Error::new(b.service_id.span, "duplicate service ID"));
 					}
+					if a.name() == b.name() {
+						errors.push(syn::Error::new(b.name().span(), "duplicate response update name"));
+						remove_response_updates.push(b_i);
+					}
 				}
+			}
+
+			for i in remove_request_updates.into_iter().rev() {
+				request_updates.remove(i);
+			}
+
+			for i in remove_response_updates.into_iter().rev() {
+				response_updates.remove(i);
 			}
 
 			Self {

--- a/macros/src/interface/parse.rs
+++ b/macros/src/interface/parse.rs
@@ -85,6 +85,23 @@ pub mod cooked {
 					raw::InterfaceItem::Stream(raw) => streams.push(StreamDefinition::from_raw(errors, raw)),
 				}
 			}
+
+			for (i, a) in services.iter().enumerate() {
+				for b in &services[i + 1..] {
+					if a.service_id.value == b.service_id.value {
+						errors.push(syn::Error::new(b.service_id.span, "duplicate service ID"));
+					}
+				}
+			}
+
+			for (i, a) in streams.iter().enumerate() {
+				for b in &streams[i + 1..] {
+					if a.service_id.value == b.service_id.value {
+						errors.push(syn::Error::new(b.service_id.span, "duplicate service ID"));
+					}
+				}
+			}
+
 			Self {
 				name: raw.name,
 				doc: attrs.doc,


### PR DESCRIPTION
This PR removes all `recv_*_update` functions, and instead adds `update.is/as/into_*()` functions.

So instead of doing `req.recv_foo_update().await?`, you'll do `req.recv_update().await?.into_foo()?`.

Aditionally, the PR adds missing checks for duplicate service IDs for services and streams, and it adds checks for duplicate service/stream/update names.