### PR TITLE
Add request write handles to allow parallel reading and writing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
 ## main
+### Added
+- Add `SentRequestWriteHandle` and `ReceivedRequestWriteHandle` to support parallel reading and writing.
+
 ### Changed
 - Renamed `PeerHandle::next_message()` to `recv_message()`.
 - Moved message body out of `ReceivedRequest`.
 - Changed `SentRequest/ReceivedRequest::recv_update()` to return an `Option<Message>`.
 - Renamed `Incoming` to `ReceivedMessage`.
+- Renamed `SentRequest` and `ReceivedRequest` to `SentRequestHandle` and `ReceivedRequestHandle`.
 
 ### Removed
 - Removed unused `Outgoing` type.

--- a/examples/tcp-server.rs
+++ b/examples/tcp-server.rs
@@ -72,7 +72,7 @@ async fn handle_peer(mut peer: fizyr_rpc::PeerHandle<fizyr_rpc::StreamBody>) -> 
 	}
 }
 
-async fn handle_hello(request: fizyr_rpc::ReceivedRequest<fizyr_rpc::StreamBody>, body: fizyr_rpc::StreamBody) -> Result<(), String> {
+async fn handle_hello(request: fizyr_rpc::ReceivedRequestHandle<fizyr_rpc::StreamBody>, body: fizyr_rpc::StreamBody) -> Result<(), String> {
 	// Parse the request body as UTF-8 and print it.
 	let message = std::str::from_utf8(&body).map_err(|_| "invalid UTF-8 in hello message")?;
 	eprintln!("received hello request: {}", message);

--- a/examples/unix-seqpacket-server.rs
+++ b/examples/unix-seqpacket-server.rs
@@ -72,7 +72,7 @@ async fn handle_peer(mut peer: fizyr_rpc::PeerHandle<fizyr_rpc::UnixBody>) -> Re
 	}
 }
 
-async fn handle_hello(request: fizyr_rpc::ReceivedRequest<fizyr_rpc::UnixBody>, body: fizyr_rpc::UnixBody) -> Result<(), String> {
+async fn handle_hello(request: fizyr_rpc::ReceivedRequestHandle<fizyr_rpc::UnixBody>, body: fizyr_rpc::UnixBody) -> Result<(), String> {
 	// Parse the request body as UTF-8 and print it.
 	let message = std::str::from_utf8(&body.data).map_err(|_| "invalid UTF-8 in hello message")?;
 	eprintln!("received hello request: {}", message);

--- a/examples/unix-stream-server.rs
+++ b/examples/unix-stream-server.rs
@@ -72,7 +72,7 @@ async fn handle_peer(mut peer: fizyr_rpc::PeerHandle<fizyr_rpc::StreamBody>) -> 
 	}
 }
 
-async fn handle_hello(request: fizyr_rpc::ReceivedRequest<fizyr_rpc::StreamBody>, body: fizyr_rpc::StreamBody) -> Result<(), String> {
+async fn handle_hello(request: fizyr_rpc::ReceivedRequestHandle<fizyr_rpc::StreamBody>, body: fizyr_rpc::StreamBody) -> Result<(), String> {
 	// Parse the request body as UTF-8 and print it.
 	let message = std::str::from_utf8(&body).map_err(|_| "invalid UTF-8 in hello message")?;
 	eprintln!("received hello request: {}", message);

--- a/macros-tests/tests/camera.rs
+++ b/macros-tests/tests/camera.rs
@@ -15,7 +15,7 @@ async fn ping() {
 	let_assert!(Ok((client, mut server)) = client_server_pair::<Json>());
 
 	let server = tokio::spawn(async move {
-		let_assert!(Ok(camera::ReceivedMessage::Request(camera::ReceivedRequest::Ping(request, ()))) = server.recv_message().await);
+		let_assert!(Ok(camera::ReceivedMessage::Request(camera::ReceivedRequestHandle::Ping(request, ()))) = server.recv_message().await);
 		assert!(let Ok(()) = request.send_response(()).await);
 		let_assert!(Err(e) = server.recv_message().await);
 		assert!(e.is_connection_aborted());
@@ -32,7 +32,7 @@ async fn record() {
 	let_assert!(Ok((client, mut server)) = client_server_pair::<Json>());
 
 	let server = tokio::spawn(async move {
-		let_assert!(Ok(camera::ReceivedMessage::Request(camera::ReceivedRequest::Record(request, body))) = server.recv_message().await);
+		let_assert!(Ok(camera::ReceivedMessage::Request(camera::ReceivedRequestHandle::Record(request, body))) = server.recv_message().await);
 		assert!(body.color == true);
 		assert!(body.cloud == false);
 		assert!(let Ok(()) = request.send_state_update(RecordState::Recording).await);

--- a/macros/src/interface/generate.rs
+++ b/macros/src/interface/generate.rs
@@ -352,32 +352,10 @@ fn generate_service(item_tokens: &mut TokenStream, client_impl_tokens: &mut Toke
 /// Otherwise, the return type of a service call will simply be the response message.
 fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, service: &ServiceDefinition) {
 	let service_name = service.name();
-	let mut impl_tokens = TokenStream::new();
-
-	if !service.request_updates().is_empty() {
-		generate_message_enum(
-			item_tokens,
-			fizyr_rpc,
-			service.request_updates(),
-			&syn::Ident::new("RequestUpdate", Span::call_site()),
-			&format!("A request update for the {} service", service.name()),
-		);
-		generate_send_update_functions(&mut impl_tokens, fizyr_rpc, &quote!(#service_name::RequestUpdate), service.request_updates());
-	}
-
-	if !service.response_updates().is_empty() {
-		generate_message_enum(
-			item_tokens,
-			fizyr_rpc,
-			service.response_updates(),
-			&syn::Ident::new("ResponseUpdate", Span::call_site()),
-			&format!("A response update for the {} service", service.name()),
-		);
-		generate_recv_update_functions(&mut impl_tokens, fizyr_rpc, &quote!(#service_name::ResponseUpdate), UpdateKind::ResponseUpdate);
-	}
+	let mut read_handle_impl_tokens = TokenStream::new();
+	let mut write_handle_impl_tokens = TokenStream::new();
 
 	let response_type = service.response_type();
-	let struct_doc = format!("A sent request for the {} service.", service.name());
 	let doc_recv_update = match service.response_updates().is_empty() {
 		true => quote! {
 			/// This service call does not support update messages, so there is no way to retrieve it.
@@ -388,10 +366,57 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 		},
 	};
 
+	read_handle_impl_tokens.extend(quote! {
+		/// Receive the final response.
+		///
+		/// If an update message is received instead of the final response an error is returned.
+		/// The update message will remain in the message queue and must be read before the response can be received.
+		///
+		#doc_recv_update
+		pub async fn recv_response(&mut self) -> Result<#response_type, #fizyr_rpc::error::RecvMessageError>
+		where
+			F: #fizyr_rpc::util::format::DecodeBody<#response_type>,
+		{
+			let response = self.request.recv_response().await?;
+			let decoded = F::decode_body(response.body).map_err(#fizyr_rpc::error::RecvMessageError::DecodeBody)?;
+			Ok(decoded)
+		}
+	});
+
+	if !service.request_updates().is_empty() {
+		generate_message_enum(
+			item_tokens,
+			fizyr_rpc,
+			service.request_updates(),
+			&syn::Ident::new("RequestUpdate", Span::call_site()),
+			&format!("A request update for the {} service", service.name()),
+		);
+		generate_send_update_functions(&mut write_handle_impl_tokens, fizyr_rpc, &quote!(#service_name::RequestUpdate), service.request_updates());
+	}
+
+	if !service.response_updates().is_empty() {
+		generate_message_enum(
+			item_tokens,
+			fizyr_rpc,
+			service.response_updates(),
+			&syn::Ident::new("ResponseUpdate", Span::call_site()),
+			&format!("A response update for the {} service", service.name()),
+		);
+		generate_recv_update_function(&mut read_handle_impl_tokens, fizyr_rpc, &quote!(#service_name::ResponseUpdate), UpdateKind::ResponseUpdate);
+	}
+
+	let handle_doc = format!("Read/write handle for a sent request for the {} service.", service.name());
+	let write_handle_doc = format!("Write handle for a sent request for the {} service.", service.name());
+
 	item_tokens.extend(quote! {
-		#[doc = #struct_doc]
+		#[doc = #handle_doc]
 		pub struct SentRequestHandle<F: #fizyr_rpc::util::format::Format> {
 			pub(super) request: #fizyr_rpc::SentRequestHandle<F::Body>,
+		}
+
+		#[doc = #write_handle_doc]
+		pub struct SentRequestWriteHandle<F: #fizyr_rpc::util::format::Format> {
+			pub(super) request: #fizyr_rpc::SentRequestWriteHandle<F::Body>,
 		}
 
 		impl<F: #fizyr_rpc::util::format::Format> ::core::fmt::Debug for SentRequestHandle<F> {
@@ -404,21 +429,17 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 			}
 		}
 
-		impl<F: #fizyr_rpc::util::format::Format> SentRequestHandle<F> {
-			/// Receive the final response.
-			///
-			/// If an update message is received instead of the final response an error is returned.
-			/// The update message will remain in the message queue and must be read before the response can be received.
-			#doc_recv_update
-			pub async fn recv_response(&mut self) -> Result<#response_type, #fizyr_rpc::error::RecvMessageError>
-			where
-				F: #fizyr_rpc::util::format::DecodeBody<#response_type>,
-			{
-				let response = self.request.recv_response().await?;
-				let decoded = F::decode_body(response.body).map_err(#fizyr_rpc::error::RecvMessageError::DecodeBody)?;
-				Ok(decoded)
+		impl<F: #fizyr_rpc::util::format::Format> ::core::fmt::Debug for SentRequestWriteHandle<F> {
+			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+				f.debug_struct(::core::any::type_name::<Self>())
+					.field("request_id", &self.request_id())
+					.field("service_id", &self.service_id())
+					// TODO: use finish_non_exhaustive when it hits stable
+					.finish()
 			}
+		}
 
+		impl<F: #fizyr_rpc::util::format::Format> SentRequestHandle<F> {
 			/// Get the raw request.
 			pub fn inner(&self) -> &#fizyr_rpc::SentRequestHandle<F::Body> {
 				&self.request
@@ -444,7 +465,38 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 				self.request.service_id()
 			}
 
-			#impl_tokens
+			#read_handle_impl_tokens
+
+			#write_handle_impl_tokens
+		}
+
+		impl<F: #fizyr_rpc::util::format::Format> SentRequestWriteHandle<F> {
+			/// Get the raw request.
+			pub fn inner(&self) -> &#fizyr_rpc::SentRequestWriteHandle<F::Body> {
+				&self.request
+			}
+
+			/// Get an exclusive reference to the raw request.
+			pub fn inner_mut(&self) -> &#fizyr_rpc::SentRequestWriteHandle<F::Body> {
+				&self.request
+			}
+
+			/// Consume this object to get the raw request.
+			pub fn into_inner(self) -> #fizyr_rpc::SentRequestWriteHandle<F::Body> {
+				self.request
+			}
+
+			/// Get the request ID.
+			pub fn request_id(&self) -> u32 {
+				self.request.request_id()
+			}
+
+			/// Get the service ID of the request.
+			pub fn service_id(&self) -> i32 {
+				self.request.service_id()
+			}
+
+			#write_handle_impl_tokens
 		}
 	});
 }
@@ -496,7 +548,7 @@ fn generate_send_update_functions(impl_tokens: &mut TokenStream, fizyr_rpc: &syn
 	}
 }
 
-fn generate_recv_update_functions(impl_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, enum_type: &TokenStream, kind: UpdateKind) {
+fn generate_recv_update_function(impl_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, enum_type: &TokenStream, kind: UpdateKind) {
 	let mut doc = quote! {
 		/// Receive an update from the remote peer.
 	};
@@ -734,20 +786,47 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 	let service_name = service.name();
 	let service_id = service.service_id();
 
-	let mut impl_tokens = TokenStream::new();
+	let mut read_handle_impl_tokens = TokenStream::new();
+	let mut write_handle_impl_tokens = TokenStream::new();
 	if !service.response_updates().is_empty() {
-		generate_send_update_functions(&mut impl_tokens, fizyr_rpc, &quote!(#service_name::ResponseUpdate), service.response_updates());
+		generate_send_update_functions(&mut write_handle_impl_tokens, fizyr_rpc, &quote!(#service_name::ResponseUpdate), service.response_updates());
 	}
 	if !service.request_updates().is_empty() {
-		generate_recv_update_functions(&mut impl_tokens, fizyr_rpc, &quote!(#service_name::RequestUpdate), UpdateKind::RequestUpdate);
+		generate_recv_update_function(&mut read_handle_impl_tokens, fizyr_rpc, &quote!(#service_name::RequestUpdate), UpdateKind::RequestUpdate);
 	}
+
+	write_handle_impl_tokens.extend(quote! {
+		/// Send the final response.
+		pub async fn send_response(&self, response: #response_type) -> Result<(), #fizyr_rpc::error::SendMessageError>
+		where
+			F: #fizyr_rpc::util::format::EncodeBody<#response_type>,
+		{
+			let encoded = F::encode_body(response).map_err(#fizyr_rpc::error::SendMessageError::EncodeBody)?;
+			let response = self.request.send_response(#service_id, encoded).await?;
+			Ok(())
+		}
+	});
 
 	item_tokens.extend(quote! {
 		pub struct ReceivedRequestHandle<F: #fizyr_rpc::util::format::Format> {
 			pub(super) request: #fizyr_rpc::ReceivedRequestHandle<F::Body>,
 		}
 
+		pub struct ReceivedRequestWriteHandle<F: #fizyr_rpc::util::format::Format> {
+			pub(super) request: #fizyr_rpc::ReceivedRequestWriteHandle<F::Body>,
+		}
+
 		impl<F: #fizyr_rpc::util::format::Format> ::core::fmt::Debug for ReceivedRequestHandle<F> {
+			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+				f.debug_struct(::core::any::type_name::<Self>())
+					.field("request_id", &self.request_id())
+					.field("service_id", &self.service_id())
+					// TODO: use finish_non_exhaustive when it hits stable
+					.finish()
+			}
+		}
+
+		impl<F: #fizyr_rpc::util::format::Format> ::core::fmt::Debug for ReceivedRequestWriteHandle<F> {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 				f.debug_struct(::core::any::type_name::<Self>())
 					.field("request_id", &self.request_id())
@@ -792,17 +871,47 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 				self.request.service_id()
 			}
 
-			/// Send the final response.
-			pub async fn send_response(self, response: #response_type) -> Result<(), #fizyr_rpc::error::SendMessageError>
-			where
-				F: #fizyr_rpc::util::format::EncodeBody<#response_type>,
-			{
-				let encoded = F::encode_body(response).map_err(#fizyr_rpc::error::SendMessageError::EncodeBody)?;
-				let response = self.request.send_response(#service_id, encoded).await?;
-				Ok(())
+			#read_handle_impl_tokens
+
+			#write_handle_impl_tokens
+		}
+
+		impl<F: #fizyr_rpc::util::format::Format> ReceivedRequestWriteHandle<F> {
+			/// Get the raw request.
+			///
+			/// Note that the request body has been consumed when it was parsed.
+			/// As a result, the raw request always has an empty body.
+			pub fn inner(&self) -> &#fizyr_rpc::ReceivedRequestWriteHandle<F::Body> {
+				&self.request
 			}
 
-			#impl_tokens
+			/// Get an exclusive reference to the raw request.
+			///
+			/// Note that the request body has been consumed when it was parsed.
+			/// As a result, the raw request always has an empty body.
+			pub fn inner_mut(&self) -> &#fizyr_rpc::ReceivedRequestWriteHandle<F::Body> {
+				&self.request
+			}
+
+			/// Consume this object to get the raw request.
+			///
+			/// Note that the request body has been consumed when it was parsed.
+			/// As a result, the raw request always has an empty body.
+			pub fn into_inner(self) -> #fizyr_rpc::ReceivedRequestWriteHandle<F::Body> {
+				self.request
+			}
+
+			/// Get the request ID.
+			pub fn request_id(&self) -> u32 {
+				self.request.request_id()
+			}
+
+			/// Get the service ID of the request.
+			pub fn service_id(&self) -> i32 {
+				self.request.service_id()
+			}
+
+			#write_handle_impl_tokens
 		}
 	})
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,6 +105,11 @@ impl PayloadTooLarge {
 	}
 }
 
+/// The request was already closed.
+#[derive(Debug, Clone, Error)]
+#[error("the request is already closed")]
+pub struct RequestClosed;
+
 /// No free request ID was found.
 #[derive(Debug, Clone, Error)]
 #[error("no free request ID was found")]
@@ -240,6 +245,9 @@ pub enum SendMessageError {
 
 	/// The payload of the message is too large to send.
 	PayloadTooLarge(#[from] PayloadTooLarge),
+
+	/// The request has already been closed.
+	RequestClosed(#[from] RequestClosed),
 
 	/// Failed to encode the message.
 	EncodeBody(Box<dyn std::error::Error + Send>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,9 +117,13 @@ pub use peer_handle::PeerHandle;
 pub use peer_handle::PeerCloseHandle;
 pub use peer_handle::PeerReadHandle;
 pub use peer_handle::PeerWriteHandle;
-pub use request::ReceivedMessage;
-pub use request::ReceivedRequest;
-pub use request::SentRequest;
+pub use request::{
+	ReceivedMessage,
+	ReceivedRequestHandle,
+	ReceivedRequestWriteHandle,
+	SentRequestHandle,
+	SentRequestWriteHandle,
+};
 pub use server::Server;
 pub use server::ServerListener;
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,14 +1,15 @@
 use crate::util::{select, Either};
-use tokio::sync::mpsc;
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 
-use crate::Message;
-use crate::PeerHandle;
-use crate::ReceivedMessage;
-use crate::SentRequest;
-use crate::error;
-use crate::request_tracker::RequestTracker;
-use crate::util;
+use crate::{
+	error,
+	util,
+	request_tracker::RequestTracker,
+	Message,
+	PeerHandle,
+	ReceivedMessage,
+	SentRequestHandle,
+};
 
 /// Message for the internal peer command loop.
 pub enum Command<Body> {
@@ -412,8 +413,8 @@ pub struct SendRequest<Body> {
 	/// The body for the request.
 	pub body: Body,
 
-	/// One-shot channel to transmit back the created [`SentRequest`] object, or an error.
-	pub result_tx: oneshot::Sender<Result<SentRequest<Body>, error::SendRequestError>>,
+	/// One-shot channel to transmit back the created [`SentRequestHandle`] object, or an error.
+	pub result_tx: oneshot::Sender<Result<SentRequestHandle<Body>, error::SendRequestError>>,
 }
 
 /// Command to send a raw message to the remote peer.

--- a/src/peer_handle.rs
+++ b/src/peer_handle.rs
@@ -5,7 +5,7 @@ use crate::error;
 use crate::peer::{Command, SendRawMessage, SendRequest};
 use crate::ReceivedMessage;
 use crate::Message;
-use crate::SentRequest;
+use crate::SentRequestHandle;
 
 /// Handle to a peer.
 ///
@@ -34,7 +34,7 @@ pub struct PeerReadHandle<Body> {
 
 	/// Channel for sending commands to the peer loop.
 	///
-	/// Used by [`ReceivedRequest`][crate::ReceivedRequest] for sending updates and the response,
+	/// Used by [`ReceivedRequestHandle`][crate::ReceivedRequestHandle] for sending updates and the response,
 	/// and to notify the peer loop when the read handle is dropped.
 	command_tx: mpsc::UnboundedSender<Command<Body>>,
 }
@@ -49,7 +49,7 @@ pub struct PeerWriteHandle<Body> {
 	/// Channel for sending commands to the peer loop.
 	///
 	/// Use amongst others to send outoing requests and stream messages,
-	/// and copied into [`SentRequest`] to send update messages.
+	/// and copied into [`SentRequestHandle`] to send update messages.
 	///
 	/// Also used to register and unregister the cloned/dropped write handles with the peer.
 	command_tx: mpsc::UnboundedSender<Command<Body>>,
@@ -99,7 +99,7 @@ impl<Body> PeerHandle<Body> {
 	}
 
 	/// Send a new request to the remote peer.
-	pub async fn send_request(&self, service_id: i32, body: impl Into<Body>) -> Result<SentRequest<Body>, error::SendRequestError> {
+	pub async fn send_request(&self, service_id: i32, body: impl Into<Body>) -> Result<SentRequestHandle<Body>, error::SendRequestError> {
 		self.write_handle.send_request(service_id, body).await
 	}
 
@@ -155,7 +155,7 @@ impl<Body> Drop for PeerReadHandle<Body> {
 
 impl<Body> PeerWriteHandle<Body> {
 	/// Send a new request to the remote peer.
-	pub async fn send_request(&self, service_id: i32, body: impl Into<Body>) -> Result<SentRequest<Body>, error::SendRequestError> {
+	pub async fn send_request(&self, service_id: i32, body: impl Into<Body>) -> Result<SentRequestHandle<Body>, error::SendRequestError> {
 		let body = body.into();
 		let (result_tx, result_rx) = oneshot::channel();
 		self.command_tx


### PR DESCRIPTION
This PR adds `SentRequestWriteHandle` and `ReceivedRequestWriteHandle`, which can be cloned as much as you want. That allows you to send updates and even the response from any thread.

I had to add a way for the cloned write handles to interrupt `recv_update/response()` on the normal handle now. That was previously unnecessary since there was only one handle in total. Whenever a request is unregistered, a `Close` command is sent to the main handle, which will then close the channel.

It may be good to read individual commits rather than all at once. I tried to keep each commit relatively straightforward and limited to doing one thing.