### PR TITLE
Add macro documentation.

### DIFF
--- a/macros-tests/src/lib.rs
+++ b/macros-tests/src/lib.rs
@@ -6,7 +6,7 @@ fizyr_rpc::interface! {
 	/// A camera server can represent many different types of cameras,
 	/// like a simple 2D camera, a 3D camera with or without RGB data,
 	/// or even a line scanner.
-	interface camera {
+	pub interface camera {
 		/// Ping the server.
 		///
 		/// A succesful ping indicates that the server is running,

--- a/macros/src/interface/generate.rs
+++ b/macros/src/interface/generate.rs
@@ -72,17 +72,6 @@ fn generate_client(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, interf
 				Self { peer }
 			}
 
-			/// Connect to a remote server.
-			///
-			/// See [`fizyr_rpc::Peer::connect`](https://docs.rs/fizyr-rpc/latest/fizyr_rpc/struct.Peer.html#method.connect) for more details.
-			pub async fn connect<'a, Transport, Address>(address: Address, config: Transport::Config) -> std::io::Result<Self>
-			where
-				Address: 'a,
-				Transport: #fizyr_rpc::transport::Transport<Body = F::Body> + #fizyr_rpc::util::Connect<'a, Address>,
-			{
-				Ok(#fizyr_rpc::Peer::<Transport>::connect(address, config).await?.into())
-			}
-
 			/// Close the connection with the remote peer.
 			pub fn close(self) {
 				self.peer.close()

--- a/macros/src/interface/generate.rs
+++ b/macros/src/interface/generate.rs
@@ -22,9 +22,10 @@ pub fn generate_interface(fizyr_rpc: &syn::Ident, interface: &InterfaceDefinitio
 	generate_client(&mut item_tokens, fizyr_rpc, interface, client_impl_tokens);
 	generate_server(&mut item_tokens, fizyr_rpc, interface);
 
+	let mod_visiblity = &interface.visibility();
 	let tokens = quote! {
 		#interface_doc
-		pub mod #interface_name {
+		#mod_visiblity mod #interface_name {
 			#[allow(unused_imports)]
 			use super::*;
 

--- a/macros/src/interface/generate.rs
+++ b/macros/src/interface/generate.rs
@@ -796,11 +796,15 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 		}
 	});
 
+	let handle_doc = format!("Handle for a received `{}` request.", service.name());
+	let write_handle_doc = format!("Write-only handle for a received `{}` request.", service.name());
 	item_tokens.extend(quote! {
+		#[doc = #handle_doc]
 		pub struct ReceivedRequestHandle<F: #fizyr_rpc::util::format::Format> {
 			pub(super) request: #fizyr_rpc::ReceivedRequestHandle<F::Body>,
 		}
 
+		#[doc = #write_handle_doc]
 		pub struct ReceivedRequestWriteHandle<F: #fizyr_rpc::util::format::Format> {
 			pub(super) request: #fizyr_rpc::ReceivedRequestWriteHandle<F::Body>,
 		}

--- a/macros/src/interface/generate.rs
+++ b/macros/src/interface/generate.rs
@@ -25,6 +25,7 @@ pub fn generate_interface(fizyr_rpc: &syn::Ident, interface: &InterfaceDefinitio
 	let tokens = quote! {
 		#interface_doc
 		pub mod #interface_name {
+			#[allow(unused_imports)]
 			use super::*;
 
 			#item_tokens
@@ -329,7 +330,9 @@ fn generate_service(item_tokens: &mut TokenStream, client_impl_tokens: &mut Toke
 	item_tokens.extend(quote! {
 		#[doc = #mod_doc]
 		pub mod #service_name {
+			#[allow(unused_imports)]
 			use super::*;
+
 			#service_item_tokens
 		}
 	});
@@ -556,7 +559,6 @@ fn generate_recv_update_function(impl_tokens: &mut TokenStream, fizyr_rpc: &syn:
 		where
 			#enum_type: #fizyr_rpc::util::format::FromMessage<F>,
 		{
-			use #fizyr_rpc::util::format::FromMessage;
 			match self.request.recv_update().await {
 				Some(x) => Ok(Some(F::decode_message(x)?)),
 				None => Ok(None),

--- a/macros/src/interface/generate.rs
+++ b/macros/src/interface/generate.rs
@@ -325,7 +325,7 @@ fn generate_service(item_tokens: &mut TokenStream, client_impl_tokens: &mut Toke
 
 	generate_received_request(&mut service_item_tokens, fizyr_rpc, service);
 
-	let mod_doc = format!("Support types for the {} service.", service.name());
+	let mod_doc = format!("Support types for the `{}` service.", service.name());
 	item_tokens.extend(quote! {
 		#[doc = #mod_doc]
 		pub mod #service_name {
@@ -394,8 +394,8 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 		generate_recv_update_function(&mut read_handle_impl_tokens, fizyr_rpc, &quote!(#service_name::ResponseUpdate), UpdateKind::ResponseUpdate);
 	}
 
-	let handle_doc = format!("Read/write handle for a sent request for the {} service.", service.name());
-	let write_handle_doc = format!("Write handle for a sent request for the {} service.", service.name());
+	let handle_doc = format!("Read/write handle for a sent request for the `{}` service.", service.name());
+	let write_handle_doc = format!("Write handle for a sent request for the `{}` service.", service.name());
 
 	item_tokens.extend(quote! {
 		#[doc = #handle_doc]
@@ -513,7 +513,7 @@ fn generate_send_update_functions(impl_tokens: &mut TokenStream, fizyr_rpc: &syn
 		let function_name = syn::Ident::new(&format!("send_{}_update", update.name()), Span::call_site());
 		let body_type = update.body_type();
 		let service_id = update.service_id();
-		let doc = format!("Send a {} update to the remote peer.", update.name());
+		let doc = format!("Send a `{}` update to the remote peer.", update.name());
 		let body_arg;
 		let body_val;
 		if is_unit_type(body_type) {
@@ -578,7 +578,7 @@ fn generate_streams(item_tokens: &mut TokenStream, client_impl_tokens: &mut Toke
 	for stream in interface.streams() {
 		let service_id = stream.service_id();
 		let fn_name = syn::Ident::new(&format!("send_{}", stream.name()), Span::call_site());
-		let fn_doc = format!("Send a {} stream message to the remote peer.", stream.name());
+		let fn_doc = format!("Send a `{}` stream message to the remote peer.", stream.name());
 		let body_arg;
 		let body_val;
 		let body_type = stream.body_type();

--- a/macros/src/interface/parse.rs
+++ b/macros/src/interface/parse.rs
@@ -15,6 +15,7 @@ pub mod cooked {
 
 	#[derive(Debug)]
 	pub struct InterfaceDefinition {
+		visibility: syn::Visibility,
 		name: syn::Ident,
 		doc: Vec<WithSpan<String>>,
 		services: Vec<ServiceDefinition>,
@@ -59,6 +60,10 @@ pub mod cooked {
 	}
 
 	impl InterfaceDefinition {
+		pub fn visibility(&self) -> &syn::Visibility {
+			&self.visibility
+		}
+
 		pub fn name(&self) -> &syn::Ident {
 			&self.name
 		}
@@ -124,6 +129,7 @@ pub mod cooked {
 			}
 
 			Self {
+				visibility: raw.visibility,
 				name: raw.name,
 				doc: attrs.doc,
 				services,
@@ -335,6 +341,7 @@ pub mod raw {
 	#[derive(Debug)]
 	pub struct InterfaceDefinition {
 		pub attrs: Vec<syn::Attribute>,
+		pub visibility: syn::Visibility,
 		pub _interface: keyword::interface,
 		pub name: syn::Ident,
 		pub _brace_token: syn::token::Brace,
@@ -415,6 +422,7 @@ pub mod raw {
 			let body;
 			Ok(Self {
 				attrs: input.call(syn::Attribute::parse_outer)?,
+				visibility: input.parse()?,
 				_interface: input.parse()?,
 				name: input.parse()?,
 				_brace_token: syn::braced!(body in input),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,9 @@ macro_rules! ready {
 #[doc(hidden)]
 pub mod macros;
 
+#[cfg(feature = "macros")]
+pub use macros::interface_example;
+
 pub mod error;
 mod message;
 mod peer;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,11 +9,11 @@ pub use fizyr_rpc_macros::interface as interface_impl;
 /// This macro generates a module with a `Client` and `Server` struct,
 /// and some more helper types.
 ///
-/// The client struct can be used to initiate requests and send stream messages.
+/// The client struct is used to initiate requests and send stream messages.
 /// It can be created from a [`PeerWriteHandle`] or a [`PeerHandle`].
 /// Note that if you create the client from a [`PeerHandle`], the [`PeerReadHandle`] will not be accessible.
 ///
-/// For the server struct it is exactly the opposite: it can be used to receive requests and stream messages.
+/// For the server struct it is exactly the opposite: it is used to receive requests and stream messages.
 /// It can be created from a [`PeerReadHandle`] or a [`PeerHandle`],
 /// but creating it from a [`PeerHandle`] will discard the [`PeerWriteHandle`].
 ///
@@ -29,14 +29,15 @@ pub use fizyr_rpc_macros::interface as interface_impl;
 ///     // The `interface` keyword defines an RPC interface.
 ///     // You must have exactly one interface definition in the macro invocation.
 ///     //
-///     // The macro generates a module with the same name containing the generated types.
+///     // The $interface_name is used as the name of a module containing the generated types.
+///     //
 ///     // You can adjust the visiblity of the generated module with the `pub` keyword as normal.
 ///     // You can use this to take full control over the public module structure,
 ///     // by declaring the interface private and re-exporting the module contents from a different location.
 ///     //
 ///     // Each item can have user written documentation.
 ///     // Simply write doc comments with triple slashes as usual.
-///     // This applies to the interface definition, a service definitions, update definitions and stream definitions.
+///     // This applies to the interface definition, service definitions, update definitions and stream definitions.
 ///     pub interface $interface_name {
 ///         // The `service` keyword defines a service.
 ///         //

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,10 +1,294 @@
+//! Extra macro documentation.
+
 #[doc(hidden)]
 pub use fizyr_rpc_macros::interface as interface_impl;
 
 #[macro_export]
 /// Define an RPC interface.
+///
+/// This macro generates a module with a `Client` and `Server` struct,
+/// and some more helper types.
+///
+/// The client struct can be used to initiate requests and send stream messages.
+/// It can be created from a [`PeerWriteHandle`] or a [`PeerHandle`].
+/// Note that if you create the client from a [`PeerHandle`], the [`PeerReadHandle`] will not be accessible.
+///
+/// For the server struct it is exacatly opposite: it can be used to receive requests and stream messages.
+/// It can be created from a [`PeerReadHandle`] or a [`PeerHandle`],
+/// but creating it from a [`PeerHandle`] will discard the [`PeerWriteHandle`].
+///
+/// # Example
+///
+/// See the [`interface_example`] module for an example, with the source code and generated documentation.
+///
+/// # Syntax
+///
+/// The syntax for the macro is as follows:
+/// ```rust
+/// fizyr_rpc::interface! {
+///     // The `interface` keyword defines an RPC interface.
+///     // You must have exactly one interface definition in the macro invocation.
+///     // The macro generates a module with the same name containing the generated types.
+///     //
+///     // Each item in can have user written documentation.
+///     // Simply write doc comments with triple slashes as usual.
+///     // This applies to the interface definition, a service definitions, update definitions and stream definitions.
+///     interface $interface_name {
+///         // The `service` keyword defines a service.
+///         //
+///         // You can have any amount of service definition inside an interface definition.
+///         //
+///         // The $id is used as the service ID and must be an i32.
+///         // The ID must be unique for all services in the interface.
+///         //
+///         // The $name is the name of the service.
+///         // It is used to generate function en type names.
+///         // It must be a valid Rust identifier and should be lower-case with underscores.
+///         //
+///         // The $request_type and $response_type indicate the message body for the request and the response.
+///         // If there is no data in a request or response, you can use the unit type: `()`
+///         service $id $name: $request_type -> $response_type,
+///
+///         // If a service has update messages, you can declare them in service a block.
+///         service $id $name: $request_type -> $response_type {
+///             // The `request_update` keyword defines a request update.
+///             // You can have any amount of request updates inside a service definition.
+///             //
+///             // The $id is used as the service ID for the update and must be an i32.
+///             // The ID must be unique for all request updates in the service.
+///             //
+///             // The $name is the name of the update message.
+///             // It is used to generate function en type names.
+///             // It must be a valid Rust identifier and should be lower-case with underscores.
+///             //
+///             // The $body_type indicates the type of the message.
+///             // If there is no data in the message, you can use the unit type: `()`
+///             request_update $id $name: $body_type,
+///
+///             // The `response_update` keyword defines a response update.
+///             // You can have any amount of response updates inside a service definition.
+///             //
+///             // The $id is used as the service ID for the update and must be an i32.
+///             // The ID must be unique for all response updates in the service.
+///             //
+///             // The $name is the name of the update message.
+///             // It is used to generate function en type names.
+///             // It must be a valid Rust identifier and should be lower-case with underscores.
+///             //
+///             // The $body_type indicates the type of the message.
+///             // If there is no data in the message, you can use the unit type: `()`
+///             response_update $id $name: $body_type,
+///         }
+///
+///         // The `stream` keyword defines a stream message.
+///         // You can have any amount of stream definitions in an interface definition.
+///         //
+///         // The $id is used as the service ID of the stream message and must be an i32.
+///         // The ID must be unique for all streams in the interface.
+///         //
+///         // The $name is the name of the stream.
+///         // It is used to generate function en type names.
+///         // It must be a valid Rust identifier and should be lower-case with underscores.
+///         //
+///         // The $body_type indicates the type of the message.
+///         // If there is no data in the message, you can use the unit type: `()`
+///        stream $id $name: $body_type,
+///     }
+/// }
+/// ```
+///
+/// [`PeerHandle`]: crate::PeerHandle
+/// [`PeerWriteHandle`]: crate::PeerWriteHandle
+/// [`PeerReadHandle`]: crate::PeerReadHandle
 macro_rules! interface {
 	($($tokens:tt)*) => {
 		$crate::macros::interface_impl!{$crate; $($tokens)*}
+	}
+}
+
+/// Example module for the `interface!` macro.
+///
+/// You can compare the source the the gerated documentation to inspect the generated API.
+/// The most important generated types are [`supermarket::Client`] and [`supermarket::Server`].
+///
+/// [`supermarket::Client`]: interface_example::supermarket::Client
+/// [`supermarket::Server`]: interface_example::supermarket::Server
+/// ```
+///
+/// fizyr_rpc::interface! {
+///     /// RPC interface for the supermarket.
+///     interface supermarket {
+///         /// Greet the cashier.
+///         ///
+///         /// The cashier will reply with their own greeting.
+///         service 1 greet_cashier: String -> String,
+///
+///         /// Purchase tomatoes.
+///         ///
+///         /// The response of the cashier depends on the update messages exchanged.
+///         /// If you run away after they have sent the `price`, or if you pay with a nun-fungable token,
+///         /// they will respond with [`BuyTomatoesResponse::ICalledSecurity`].
+///         ///
+///         /// If you pay with the correct amount, they will respond with [`BuyTomatoesResponse::ThankYouComeAgain`].
+///         service 2 buy_tomatoes: BuyTomatoesRequest -> BuyTomatoesResponse {
+///             /// Sent once by the cashier to notify you of the price of the tomatoes.
+///             response_update 1 price: Price,
+///
+///             /// Sent by the client to pay for the tomatoes.
+///             request_update 1 pay: Payment,
+///
+///             /// Sent by broke or kleptomanic clients that still want tomatoes.
+///             request_update 2 run_away: (),
+///         }
+///
+///         /// Mutter something as you're walking through the supermarket.
+///         ///
+///         /// Since no-one will respond, this is a stream rather than a service.
+///         ///
+///         /// Popular phrases include:
+///         ///  * Woah thats cheap!
+///         ///  * Everything used to be better in the old days...
+///         ///  * Why did they move the toilet paper?
+///         stream 1 mutter: String,
+///     }
+/// }
+///
+/// /// The initial request to buy tomatoes.
+/// #[derive(Debug)]
+/// pub struct BuyTomatoesRequest {
+///     /// The tomatoes you want to buy.
+///     pub amount: usize,
+/// }
+///
+/// /// The price for something.
+/// #[derive(Debug)]
+/// pub struct Price {
+///     /// The total price in cents.
+///     pub total_price_cents: usize,
+/// }
+///
+/// /// Payment options for purchasing tomatoes.
+/// #[derive(Debug)]
+/// pub enum Payment {
+///     /// Payment in money.
+///     Money {
+///         /// The amount of money in cents.
+///         cents: usize
+///     },
+///
+///     /// Payment with an NFT.
+///     NonFungableToken,
+/// }
+///
+/// /// The response of a cashier when buying tomatoes.
+/// #[derive(Debug)]
+/// pub enum BuyTomatoesResponse {
+///     /// A final greeting and your receipt.
+///     ThankYouComeAgain(Receipt),
+///
+///     /// Security has been called.
+///     ICalledSecurity,
+/// }
+///
+/// /// A receipt for your purchase.
+/// #[derive(Debug)]
+/// pub struct Receipt {
+///     /// The number of tomatoes you bought.
+///     pub amount_of_tomatoes: usize,
+///
+///     /// The total price you paid for the tomatoes.
+///     pub total_price_cents: usize,
+///
+///     /// If the cashier really liked you, they may write their phone number on the receipt with pen.
+///     pub phone_number: Option<String>,
+/// }
+/// ```
+pub mod interface_example {
+	interface! {
+		/// RPC interface for the supermarket.
+		interface supermarket {
+			/// Greet the cashier.
+			///
+			/// The cashier will reply with their own greeting.
+			service 1 greet_cashier: String -> String,
+
+			/// Purchase tomatoes.
+			///
+			/// The response of the cashier depends on the update messages exchanged.
+			/// If you run away after they have sent the `price`, or if you pay with a nun-fungable token,
+			/// they will respond with [`BuyTomatoesResponse::ICalledSecurity`].
+			///
+			/// If you pay with the correct amount, they will respond with [`BuyTomatoesResponse::ThankYouComeAgain`].
+			service 2 buy_tomatoes: BuyTomatoesRequest -> BuyTomatoesResponse {
+				/// Sent once by the cashier to notify you of the price of the tomatoes.
+				response_update 1 price: Price,
+
+				/// Sent by the client to pay for the tomatoes.
+				request_update 1 pay: Payment,
+
+				/// Sent by broke or kleptomanic clients that still want tomatoes.
+				request_update 2 run_away: (),
+			}
+
+			/// Mutter something as you're walking through the supermarket.
+			///
+			/// Since no-one will respond, this is a stream rather than a service.
+			///
+			/// Popular phrases include:
+			///  * Woah thats cheap!
+			///  * Everything used to be better in the old days...
+			///  * Why did they move the toilet paper?
+			stream 1 mutter: String,
+		}
+	}
+
+	/// The initial request to buy tomatoes.
+	#[derive(Debug)]
+	pub struct BuyTomatoesRequest {
+		/// The tomatoes you want to buy.
+		pub amount: usize,
+	}
+
+	/// The price for something.
+	#[derive(Debug)]
+	pub struct Price {
+		/// The total price in cents.
+		pub total_price_cents: usize,
+	}
+
+	/// Payment options for purchasing tomatoes.
+	#[derive(Debug)]
+	pub enum Payment {
+		/// Payment in money.
+		Money {
+			/// The amount of money, in cents.
+			cents: usize,
+		},
+
+		/// Payment with an NFT.
+		NonFungableToken,
+	}
+
+	/// The response of a cashier when buying tomatoes.
+	#[derive(Debug)]
+	pub enum BuyTomatoesResponse {
+		/// A final greeting and your receipt.
+		ThankYouComeAgain(Receipt),
+
+		/// Security has been called.
+		ICalledSecurity,
+	}
+
+	/// A receipt for your purchase.
+	#[derive(Debug)]
+	pub struct Receipt {
+		/// The number of tomatoes you bought.
+		pub amount_of_tomatoes: usize,
+
+		/// The total price you paid for the tomatoes.
+		pub total_price_cents: usize,
+
+		/// If the cashier really liked you, they may write their phone number on the receipt with pen.
+		pub phone_number: Option<String>,
 	}
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -52,9 +52,12 @@ pub use fizyr_rpc_macros::interface as interface_impl;
 ///         //
 ///         // The $request_type and $response_type indicate the message body for the request and the response.
 ///         // If there is no data in a request or response, you can use the unit type: `()`
+///         //
+///         // If the service has no update messages, you can end the definition with a comma.
+///         // See the next item for the syntax of services with update messages.
 ///         service $id $name: $request_type -> $response_type,
 ///
-///         // If a service has update messages, you can declare them in service a block.
+///         // If a service has update messages, you can declare them in the service block.
 ///         service $id $name: $request_type -> $response_type {
 ///             // The `request_update` keyword defines a request update.
 ///             // You can have any amount of request updates inside a service definition.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -28,12 +28,16 @@ pub use fizyr_rpc_macros::interface as interface_impl;
 /// fizyr_rpc::interface! {
 ///     // The `interface` keyword defines an RPC interface.
 ///     // You must have exactly one interface definition in the macro invocation.
+///     //
 ///     // The macro generates a module with the same name containing the generated types.
+///     // You can adjust the visiblity of the generated module with the `pub` keyword as normal.
+///     // You can use this to take full control over the public module structure,
+///     // by declaring the interface private and re-exporting the module contents from a different location.
 ///     //
 ///     // Each item in can have user written documentation.
 ///     // Simply write doc comments with triple slashes as usual.
 ///     // This applies to the interface definition, a service definitions, update definitions and stream definitions.
-///     interface $interface_name {
+///     pub interface $interface_name {
 ///         // The `service` keyword defines a service.
 ///         //
 ///         // You can have any amount of service definition inside an interface definition.
@@ -111,8 +115,8 @@ macro_rules! interface {
 /// You can compare the source the the gerated documentation to inspect the generated API.
 /// The most important generated types are [`supermarket::Client`] and [`supermarket::Server`].
 ///
-/// [`supermarket::Client`]: interface_example::supermarket::Client
-/// [`supermarket::Server`]: interface_example::supermarket::Server
+/// [`supermarket::Client`]: interface_example::Client
+/// [`supermarket::Server`]: interface_example::Server
 /// ```
 ///
 /// fizyr_rpc::interface! {
@@ -152,6 +156,11 @@ macro_rules! interface {
 ///         stream 1 mutter: String,
 ///     }
 /// }
+///
+/// // Re-export the generated contents directly in this module.
+/// //
+/// // Alternatively, you could use `pub interface` in the macro.
+/// pub use supermarket::*;
 ///
 /// /// The initial request to buy tomatoes.
 /// #[derive(Debug)]
@@ -241,6 +250,8 @@ pub mod interface_example {
 			stream 1 mutter: String,
 		}
 	}
+
+	pub use supermarket::*;
 
 	/// The initial request to buy tomatoes.
 	#[derive(Debug)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -151,7 +151,7 @@ macro_rules! interface {
 ///         ///
 ///         /// Popular phrases include:
 ///         ///  * Woah thats cheap!
-///         ///  * Everything used to be better in the old days...
+///         ///  * Everything used to be better in the good old days...
 ///         ///  * Why did they move the toilet paper?
 ///         stream 1 mutter: String,
 ///     }
@@ -186,7 +186,7 @@ macro_rules! interface {
 ///     },
 ///
 ///     /// Payment with an NFT.
-///     NonFungableToken,
+///     NonFungibleToken,
 /// }
 ///
 /// /// The response of a cashier when buying tomatoes.
@@ -245,7 +245,7 @@ pub mod interface_example {
 			///
 			/// Popular phrases include:
 			///  * Woah thats cheap!
-			///  * Everything used to be better in the old days...
+			///  * Everything used to be better in the good old days...
 			///  * Why did they move the toilet paper?
 			stream 1 mutter: String,
 		}
@@ -277,7 +277,7 @@ pub mod interface_example {
 		},
 
 		/// Payment with an NFT.
-		NonFungableToken,
+		NonFungibleToken,
 	}
 
 	/// The response of a cashier when buying tomatoes.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,7 +13,7 @@ pub use fizyr_rpc_macros::interface as interface_impl;
 /// It can be created from a [`PeerWriteHandle`] or a [`PeerHandle`].
 /// Note that if you create the client from a [`PeerHandle`], the [`PeerReadHandle`] will not be accessible.
 ///
-/// For the server struct it is exacatly opposite: it can be used to receive requests and stream messages.
+/// For the server struct it is exactly the opposite: it can be used to receive requests and stream messages.
 /// It can be created from a [`PeerReadHandle`] or a [`PeerHandle`],
 /// but creating it from a [`PeerHandle`] will discard the [`PeerWriteHandle`].
 ///
@@ -34,20 +34,20 @@ pub use fizyr_rpc_macros::interface as interface_impl;
 ///     // You can use this to take full control over the public module structure,
 ///     // by declaring the interface private and re-exporting the module contents from a different location.
 ///     //
-///     // Each item in can have user written documentation.
+///     // Each item can have user written documentation.
 ///     // Simply write doc comments with triple slashes as usual.
 ///     // This applies to the interface definition, a service definitions, update definitions and stream definitions.
 ///     pub interface $interface_name {
 ///         // The `service` keyword defines a service.
 ///         //
-///         // You can have any amount of service definition inside an interface definition.
+///         // You can have any amount of service definitions inside an interface definition.
 ///         //
 ///         // The $id is used as the service ID and must be an i32.
 ///         // The ID must be unique for all services in the interface.
 ///         //
 ///         // The $name is the name of the service.
-///         // It is used to generate function en type names.
-///         // It must be a valid Rust identifier and should be lower-case with underscores.
+///         // It is used to generate function and type names.
+///         // It must be a valid Rust identifier and should be lowercase with underscores.
 ///         //
 ///         // The $request_type and $response_type indicate the message body for the request and the response.
 ///         // If there is no data in a request or response, you can use the unit type: `()`
@@ -62,8 +62,8 @@ pub use fizyr_rpc_macros::interface as interface_impl;
 ///             // The ID must be unique for all request updates in the service.
 ///             //
 ///             // The $name is the name of the update message.
-///             // It is used to generate function en type names.
-///             // It must be a valid Rust identifier and should be lower-case with underscores.
+///             // It is used to generate function and type names.
+///             // It must be a valid Rust identifier and should be lowercase with underscores.
 ///             //
 ///             // The $body_type indicates the type of the message.
 ///             // If there is no data in the message, you can use the unit type: `()`
@@ -76,8 +76,8 @@ pub use fizyr_rpc_macros::interface as interface_impl;
 ///             // The ID must be unique for all response updates in the service.
 ///             //
 ///             // The $name is the name of the update message.
-///             // It is used to generate function en type names.
-///             // It must be a valid Rust identifier and should be lower-case with underscores.
+///             // It is used to generate function and type names.
+///             // It must be a valid Rust identifier and should be lowercase with underscores.
 ///             //
 ///             // The $body_type indicates the type of the message.
 ///             // If there is no data in the message, you can use the unit type: `()`
@@ -91,8 +91,8 @@ pub use fizyr_rpc_macros::interface as interface_impl;
 ///         // The ID must be unique for all streams in the interface.
 ///         //
 ///         // The $name is the name of the stream.
-///         // It is used to generate function en type names.
-///         // It must be a valid Rust identifier and should be lower-case with underscores.
+///         // It is used to generate function and type names.
+///         // It must be a valid Rust identifier and should be lowercase with underscores.
 ///         //
 ///         // The $body_type indicates the type of the message.
 ///         // If there is no data in the message, you can use the unit type: `()`
@@ -112,7 +112,7 @@ macro_rules! interface {
 
 /// Example module for the `interface!` macro.
 ///
-/// You can compare the source the the gerated documentation to inspect the generated API.
+/// You can compare the source of the generated documentation to inspect the generated API.
 /// The most important generated types are [`supermarket::Client`] and [`supermarket::Server`].
 ///
 /// [`supermarket::Client`]: interface_example::Client


### PR DESCRIPTION
This PR adds documentation for the `interface!` macro.

The `macros` feature is not enabled by default, so to read the docs in a browser, run: `cargo doc --all-features --open`