### PR TITLE
Totally rework errors and support remote errors in generated interfaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@
 - Changed `SentRequest/ReceivedRequest::recv_update()` to return an `Option<Message>`.
 - Renamed `Incoming` to `ReceivedMessage`.
 - Renamed `SentRequest` and `ReceivedRequest` to `SentRequestHandle` and `ReceivedRequestHandle`.
+- Switched to a single opaque error type.
 
 ### Removed
 - Removed unused `Outgoing` type.
+- Removed all old error types and the `error` module.
 
 ## v0.4.2 - 2021-05-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 ### Added
 - Add `SentRequestWriteHandle` and `ReceivedRequestWriteHandle` to support parallel reading and writing.
+- Add `Body::as_error()` and `Body::into_error()` as required functions on the `Body` trait.
 
 ### Changed
 - Renamed `PeerHandle::next_message()` to `recv_message()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Removed unused `Outgoing` type.
 - Removed all old error types and the `error` module.
 
+### Fixed
+- Fixed accepting connections with Unix stream sockets.
+
 ## v0.4.2 - 2021-05-20
 ### Fixed
 - Fixed bug where a sent request was untracked once a response to a received request was sent.

--- a/macros/src/interface/generate.rs
+++ b/macros/src/interface/generate.rs
@@ -305,7 +305,7 @@ fn generate_service(item_tokens: &mut TokenStream, client_impl_tokens: &mut Toke
 				let mut request = self.peer.send_request(#service_id, request_body).await?;
 
 				let response = request.recv_response().await?;
-				if response.header.service_id == -1 {
+				if response.header.service_id == #fizyr_rpc::service_id::ERROR {
 					use #fizyr_rpc::Body;
 					let message = response.body
 						.into_error()
@@ -380,7 +380,7 @@ fn generate_sent_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ident, 
 			F: #fizyr_rpc::util::format::DecodeBody<#response_type>,
 		{
 			let response = self.request.recv_response().await?;
-			if response.header.service_id == -1 {
+			if response.header.service_id == #fizyr_rpc::service_id::ERROR {
 				use #fizyr_rpc::Body;
 				let message = response.body
 					.into_error()

--- a/macros/src/interface/generate.rs
+++ b/macros/src/interface/generate.rs
@@ -816,8 +816,7 @@ fn generate_received_request(item_tokens: &mut TokenStream, fizyr_rpc: &syn::Ide
 		}
 
 		/// Send the final response.
-		pub async fn send_error_response(&self, error: &str) -> Result<(), #fizyr_rpc::Error>
-		{
+		pub async fn send_error_response(&self, error: &str) -> Result<(), #fizyr_rpc::Error> {
 			Ok(self.request.send_error_response(error).await?)
 		}
 	});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub mod macros;
 #[cfg(feature = "macros")]
 pub use macros::interface_example;
 
-pub mod error;
+mod error;
 mod message;
 mod peer;
 mod peer_handle;
@@ -108,6 +108,7 @@ mod server;
 pub mod transport;
 pub mod util;
 
+pub use error::Error;
 pub use message::service_id;
 pub use message::Body;
 pub use message::Message;

--- a/src/message.rs
+++ b/src/message.rs
@@ -20,6 +20,16 @@ pub trait Body: Send + Sync + Sized + 'static {
 
 	/// Create a message body from an error message.
 	fn from_error(message: &str) -> Self;
+
+	/// Interpret a body as error message.
+	///
+	/// You should only call this if you know that the body represent an error message.
+	fn as_error(&self) -> Result<&str, std::str::Utf8Error>;
+
+	/// Interpret a body as error message.
+	///
+	/// You should only call this if you know that the body represent an error message.
+	fn into_error(self) -> Result<String, std::string::FromUtf8Error>;
 }
 
 /// Well-known service IDs.

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,5 @@
-use crate::error;
+use crate::Error;
+use crate::error::private::InnerError;
 
 /// The encoded length of a message header.
 ///
@@ -109,14 +110,14 @@ pub enum MessageType {
 
 impl MessageType {
 	/// Try to convert a [`u32`] into a [`MessageType`]
-	pub fn from_u32(value: u32) -> Result<Self, error::InvalidMessageType> {
+	pub fn from_u32(value: u32) -> Result<Self, Error> {
 		match value {
 			0 => Ok(Self::Request),
 			1 => Ok(Self::Response),
 			2 => Ok(Self::RequesterUpdate),
 			3 => Ok(Self::ResponderUpdate),
 			4 => Ok(Self::Stream),
-			value => Err(error::InvalidMessageType { value }),
+			value => Err(InnerError::InvalidMessageType { value }.into()),
 		}
 	}
 
@@ -225,7 +226,7 @@ impl MessageHeader {
 	///
 	/// # Panic
 	/// This function panics if the buffer does not contain a full header.
-	pub fn decode(buffer: &[u8]) -> Result<Self, error::InvalidMessageType> {
+	pub fn decode(buffer: &[u8]) -> Result<Self, Error> {
 		use byteorder::{ByteOrder, LE};
 		let message_type = LE::read_u32(&buffer[0..]);
 		let request_id = LE::read_u32(&buffer[4..]);

--- a/src/transport/stream/body.rs
+++ b/src/transport/stream/body.rs
@@ -20,6 +20,14 @@ impl crate::Body for StreamBody {
 	fn from_error(message: &str) -> Self {
 		Self::new(message.as_bytes().into())
 	}
+
+	fn as_error(&self) -> Result<&str, std::str::Utf8Error> {
+		std::str::from_utf8(&self.data)
+	}
+
+	fn into_error(self) -> Result<String, std::string::FromUtf8Error> {
+		String::from_utf8(self.data)
+	}
 }
 
 impl<T> From<T> for StreamBody

--- a/src/transport/unix/body.rs
+++ b/src/transport/unix/body.rs
@@ -34,6 +34,14 @@ impl crate::Body for UnixBody {
 	fn from_error(message: &str) -> Self {
 		Self::from(message.as_bytes())
 	}
+
+	fn as_error(&self) -> Result<&str, std::str::Utf8Error> {
+		std::str::from_utf8(&self.data)
+	}
+
+	fn into_error(self) -> Result<String, std::string::FromUtf8Error> {
+		String::from_utf8(self.data)
+	}
 }
 
 impl From<Vec<u8>> for UnixBody {

--- a/src/util/accept.rs
+++ b/src/util/accept.rs
@@ -66,9 +66,7 @@ impl Listener for tokio::net::UnixListener {
 	type Connection = tokio::net::UnixStream;
 
 	fn poll_accept(self: Pin<&mut Self>, context: &mut Context) -> Poll<std::io::Result<(Self::Connection, Self::Address)>> {
-		let accept = tokio::net::UnixListener::accept(self.get_mut());
-		tokio::pin!(accept);
-		let (socket, _address) = ready!(accept.poll(context))?;
+		let (socket, _addr) = ready!(tokio::net::UnixListener::poll_accept(self.get_mut(), context))?;
 		Poll::Ready(Ok((socket, ())))
 	}
 }

--- a/src/util/format.rs
+++ b/src/util/format.rs
@@ -1,5 +1,7 @@
 //! Traits for converting between RPC messages and Rust values.
 
+use crate::Error;
+
 /// A message format, used to encode/decode RPC messages from/to Rust types.
 pub trait Format {
 	/// The body type for the RPC messages.
@@ -13,7 +15,7 @@ pub trait Format {
 	}
 
 	/// Decode a message to a Rust value.
-	fn decode_message<T: FromMessage<Self>>(message: crate::Message<Self::Body>) -> Result<T, crate::error::FromMessageError> {
+	fn decode_message<T: FromMessage<Self>>(message: crate::Message<Self::Body>) -> Result<T, Error> {
 		T::from_message(message)
 	}
 }
@@ -49,5 +51,5 @@ pub trait ToMessage<F: Format + ?Sized> {
 /// It is intended for enums that represent all possible messages for a specific interface.
 pub trait FromMessage<F: Format + ?Sized>: Sized {
 	/// Decode a message to the Rust value.
-	fn from_message(message: crate::Message<F::Body>) -> Result<Self, crate::error::FromMessageError>;
+	fn from_message(message: crate::Message<F::Body>) -> Result<Self, Error>;
 }


### PR DESCRIPTION
This PR completely changes the way errors are reported to users.

They're now an opaque error type with some public constructors and accessors. This may look less nice than it was before, but it hugely simplifies maintaining the crate since we can more easily change the `InnerError` without breaking backwards compatibility. It also hugely reduced the number of unique error types, which also helps with maintenance.

The error rework was done to add support for remote errors in generated interfaces, which is also part of this PR.