### PR TITLE
Use constant instead of magic number.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -127,7 +127,7 @@ pub(crate) mod private {
 		Io(#[from] std::io::Error),
 
 		/// The received message is too short to be valid.
-		#[error("the message is too short to be valid: need atleast 12 bytes for the header, got only {message_len} bytes")]
+		#[error("the message is too short to be valid: need at least {} for the header, got only {message_len} bytes", crate::HEADER_LEN)]
 		MessageTooShort {
 			message_len: usize,
 		},


### PR DESCRIPTION
I was hoping to remove [this](https://github.com/fizyr/fizyr-rpc/blob/main/src/error.rs#L136) magic number as well, but I don't see how. One option is to depend on [enum-unitary](https://crates.io/crates/enum-unitary), another is to reference `MessageType::Stream`, as it is the last element in the enum. Both are not exactly ideal. One adds a dependency, the other is an error waiting to happen (though it is unlikely additional types will be added frequently, if ever).