### PR TITLE
Support big endian headers in addition to little endian.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+# Unreleased
+- [change][major] Mark `StreamConfig` and `UnixConfig` as non-exhaustive structs.
+- [change][major] Make the `MessageHeader::encode/decode()` functions take an `endian` parameter.
+- [add][major] Add an `endian` field to `StreamConfig` and `UnixConfig`.
+
 # Version 0.7.1 - 2023-11-26
 - [change][patch] Remove dependency on `byteorder` crate.
 

--- a/src/transport/endian.rs
+++ b/src/transport/endian.rs
@@ -21,7 +21,7 @@ impl Endian {
 		}
 	}
 
-	/// Write a [`u32`] to a buffer in thcorrect endianness.
+	/// Write a [`u32`] to a buffer in the correct endianness.
 	pub(crate) fn write_u32(self, buffer: &mut [u8], value: u32) {
 		let bytes = match self {
 			Self::LittleEndian => value.to_le_bytes(),
@@ -39,7 +39,7 @@ impl Endian {
 		}
 	}
 
-	/// Write a [`i32`] to a buffer in thcorrect endianness.
+	/// Write a [`i32`] to a buffer in the correct endianness.
 	pub(crate) fn write_i32(self, buffer: &mut [u8], value: i32) {
 		let bytes = match self {
 			Self::LittleEndian => value.to_le_bytes(),

--- a/src/transport/endian.rs
+++ b/src/transport/endian.rs
@@ -1,0 +1,50 @@
+/// The endianness to use for encoding header fields.
+///
+/// The encoding and serialization of message bodies is up to the application code,
+/// and it not affected by this configuration parameter.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum Endian {
+	/// Encode header fields in little endian.
+	LittleEndian,
+
+	/// Encode header fields in big endian.
+	BigEndian,
+}
+
+impl Endian {
+	/// Read a [`u32`] from a buffer in the correct endianness.
+	pub(crate) fn read_u32(self, buffer: &[u8]) -> u32 {
+		let buffer = buffer[0..4].try_into().unwrap();
+		match self {
+			Self::LittleEndian => u32::from_le_bytes(buffer),
+			Self::BigEndian => u32::from_be_bytes(buffer),
+		}
+	}
+
+	/// Write a [`u32`] to a buffer in thcorrect endianness.
+	pub(crate) fn write_u32(self, buffer: &mut [u8], value: u32) {
+		let bytes = match self {
+			Self::LittleEndian => value.to_le_bytes(),
+			Self::BigEndian => value.to_be_bytes(),
+		};
+		buffer[0..4].copy_from_slice(&bytes);
+	}
+
+	/// Read a [`i32`] from a buffer in the correct endianness.
+	pub(crate) fn read_i32(self, buffer: &[u8]) -> i32 {
+		let buffer = buffer[0..4].try_into().unwrap();
+		match self {
+			Self::LittleEndian => i32::from_le_bytes(buffer),
+			Self::BigEndian => i32::from_be_bytes(buffer),
+		}
+	}
+
+	/// Write a [`i32`] to a buffer in thcorrect endianness.
+	pub(crate) fn write_i32(self, buffer: &mut [u8], value: i32) {
+		let bytes = match self {
+			Self::LittleEndian => value.to_le_bytes(),
+			Self::BigEndian => value.to_be_bytes(),
+		};
+		buffer[0..4].copy_from_slice(&bytes);
+	}
+}

--- a/src/transport/endian.rs
+++ b/src/transport/endian.rs
@@ -48,3 +48,69 @@ impl Endian {
 		buffer[0..4].copy_from_slice(&bytes);
 	}
 }
+
+#[cfg(test)]
+mod test {
+	use super::Endian;
+	use assert2::assert;
+
+	#[test]
+	fn write_u32_litte_endian_works() {
+		let mut buffer = [0u8; 4];
+		Endian::LittleEndian.write_u32(&mut buffer, 0x01020304);
+		assert!(buffer == [0x04, 0x03, 0x02, 0x01]);
+	}
+
+	#[test]
+	fn write_u32_big_endian_works() {
+		let mut buffer = [0u8; 4];
+		Endian::BigEndian.write_u32(&mut buffer, 0x01020304);
+		assert!(buffer == [0x01, 0x02, 0x03, 0x04]);
+	}
+
+	#[test]
+	fn read_u32_litte_endian_works() {
+		assert!(Endian::LittleEndian.read_u32(&[0x04, 0x03, 0x02, 0x01]) == 0x01020304);
+	}
+
+	#[test]
+	fn read_u32_big_endian_works() {
+		assert!(Endian::BigEndian.read_u32(&[0x01, 0x02, 0x03, 0x04]) == 0x01020304);
+	}
+
+	#[test]
+	fn write_i32_litte_endian_works() {
+		let mut buffer = [0u8; 4];
+		Endian::LittleEndian.write_i32(&mut buffer, 0x01020304);
+		assert!(buffer == [0x04, 0x03, 0x02, 0x01]);
+
+		// 0x80000000 - 0x7efdfcfd = 0x01020305
+		Endian::LittleEndian.write_i32(&mut buffer, -0x7efdfcfb);
+		assert!(buffer == [0x05, 0x03, 0x02, 0x81]);
+	}
+
+	#[test]
+	fn write_i32_big_endian_works() {
+		let mut buffer = [0u8; 4];
+		Endian::BigEndian.write_i32(&mut buffer, 0x01020304);
+		assert!(buffer == [0x01, 0x02, 0x03, 0x04]);
+
+		// 0x80000000 - 0x7efdfcfd = 0x01020305
+		Endian::BigEndian.write_i32(&mut buffer, -0x7efdfcfb);
+		assert!(buffer == [0x81, 0x02, 0x03, 0x05]);
+	}
+
+	#[test]
+	fn read_i32_litte_endian_works() {
+		assert!(Endian::LittleEndian.read_i32(&[0x04, 0x03, 0x02, 0x01]) == 0x01020304);
+		// 0x80000000 - 0x7efdfcfd = 0x01020305
+		assert!(Endian::LittleEndian.read_i32(&[0x05, 0x03, 0x02, 0x81]) == -0x7efdfcfb);
+	}
+
+	#[test]
+	fn read_i32_big_endian_works() {
+		assert!(Endian::BigEndian.read_i32(&[0x01, 0x02, 0x03, 0x04]) == 0x01020304);
+		// 0x80000000 - 0x7efdfcfd = 0x01020305
+		assert!(Endian::BigEndian.read_i32(&[0x81, 0x02, 0x03, 0x05]) == -0x7efdfcfb);
+	}
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -12,6 +12,9 @@ use std::task::{Context, Poll};
 
 use crate::{Error, Message, MessageHeader};
 
+mod endian;
+pub use endian::Endian;
+
 pub(crate) mod stream;
 pub use stream::StreamTransport;
 

--- a/src/transport/stream/config.rs
+++ b/src/transport/stream/config.rs
@@ -1,5 +1,8 @@
+use crate::transport::Endian;
+
 /// Configuration for a byte-stream transport.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct StreamConfig {
 	/// The maximum body size for incoming messages.
 	///
@@ -13,6 +16,12 @@ pub struct StreamConfig {
 	/// the message is discarded and an error is returned.
 	/// Stream sockets remain usable since the message header will not be sent either.
 	pub max_body_len_write: u32,
+
+	/// The endianness to use when encoding/decoding header fields.
+	///
+	/// The encoding and serialization of message bodies is up to the application code,
+	/// and it not affected by this configuration parameter.
+	pub endian: Endian,
 }
 
 impl Default for StreamConfig {
@@ -20,6 +29,7 @@ impl Default for StreamConfig {
 		Self {
 			max_body_len_read: 8 * 1024,
 			max_body_len_write: 8 * 1024,
+			endian: Endian::LittleEndian,
 		}
 	}
 }

--- a/src/transport/stream/mod.rs
+++ b/src/transport/stream/mod.rs
@@ -53,8 +53,8 @@ mod impl_unix_stream {
 
 		fn split(&mut self) -> (StreamReadHalf<tokio::net::unix::ReadHalf>, StreamWriteHalf<tokio::net::unix::WriteHalf>) {
 			let (read_half, write_half) = self.stream.split();
-			let read_half = StreamReadHalf::new(read_half, self.config.max_body_len_read);
-			let write_half = StreamWriteHalf::new(write_half, self.config.max_body_len_write);
+			let read_half = StreamReadHalf::new(read_half, self.config.max_body_len_read, self.config.endian);
+			let write_half = StreamWriteHalf::new(write_half, self.config.max_body_len_write, self.config.endian);
 			(read_half, write_half)
 		}
 
@@ -155,8 +155,8 @@ mod impl_tcp {
 
 		fn split(&mut self) -> (StreamReadHalf<tokio::net::tcp::ReadHalf>, StreamWriteHalf<tokio::net::tcp::WriteHalf>) {
 			let (read_half, write_half) = self.stream.split();
-			let read_half = StreamReadHalf::new(read_half, self.config.max_body_len_read);
-			let write_half = StreamWriteHalf::new(write_half, self.config.max_body_len_write);
+			let read_half = StreamReadHalf::new(read_half, self.config.max_body_len_read, self.config.endian);
+			let write_half = StreamWriteHalf::new(write_half, self.config.max_body_len_write, self.config.endian);
 			(read_half, write_half)
 		}
 

--- a/src/transport/unix/config.rs
+++ b/src/transport/unix/config.rs
@@ -1,5 +1,8 @@
+use crate::transport::Endian;
+
 /// Configuration for Unix datagram transports.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct UnixConfig {
 	/// The maximum body size for incoming messages.
 	///
@@ -22,6 +25,12 @@ pub struct UnixConfig {
 
 	/// The maximum number of attached file descriptors for sending messages.
 	pub max_fds_write: u32,
+
+	/// The endianness to use when encoding/decoding header fields.
+	///
+	/// The encoding and serialization of message bodies is up to the application code,
+	/// and it not affected by this configuration parameter.
+	pub endian: Endian,
 }
 
 impl Default for UnixConfig {
@@ -31,6 +40,7 @@ impl Default for UnixConfig {
 			max_body_len_write: 4 * 1024,
 			max_fds_read: 10,
 			max_fds_write: 10,
+			endian: Endian::LittleEndian,
 		}
 	}
 }

--- a/src/transport/unix/config.rs
+++ b/src/transport/unix/config.rs
@@ -40,7 +40,7 @@ impl Default for UnixConfig {
 			max_body_len_write: 4 * 1024,
 			max_fds_read: 10,
 			max_fds_write: 10,
-			endian: Endian::LittleEndian,
+			endian: Endian::NativeEndian,
 		}
 	}
 }

--- a/src/transport/unix/mod.rs
+++ b/src/transport/unix/mod.rs
@@ -53,8 +53,8 @@ mod impl_unix_seqpacket {
 
 		fn split(&mut self) -> (UnixReadHalf<&tokio_seqpacket::UnixSeqpacket>, UnixWriteHalf<&tokio_seqpacket::UnixSeqpacket>) {
 			let (read_half, write_half) = (&self.socket, &self.socket);
-			let read_half = UnixReadHalf::new(read_half, self.config.max_body_len_read, self.config.max_fds_read);
-			let write_half = UnixWriteHalf::new(write_half, self.config.max_body_len_write, self.config.max_fds_write);
+			let read_half = UnixReadHalf::new(read_half, self.config.max_body_len_read, self.config.max_fds_read, self.config.endian);
+			let write_half = UnixWriteHalf::new(write_half, self.config.max_body_len_write, self.config.max_fds_write, self.config.endian);
 			(read_half, write_half)
 		}
 


### PR DESCRIPTION
Decided to go with a runtime setting. I expect overhead to be negligible.

This is sadly a major change, but in the future we could add config fields with a minor change, since the structs are now marked as non-exhaustive.

But since its a major change now anyway, I didn't preserve backwards compatibility for `MessageHeader::encode/decode` either.