### PR TITLE
Feature gate unix and tcp transports

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@master
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,30 @@ fizyr-rpc-macros = { version = "0.8.0", path = "macros", optional = true }
 assert2 = "0.3.11"
 clap = { version = "4.4.4", features = ["derive"] }
 tokio = { version = "1.32.0", features = ["macros"] }
-fizyr-rpc = { path = ".", features = ["unix-seqpacket", "unix-stream", "tcp"] }
+
+[[example]]
+name = "tcp-client"
+required-features = ["tcp"]
+
+[[example]]
+name = "tcp-server"
+required-features = ["tcp"]
+
+[[example]]
+name = "unix-stream-client"
+required-features = ["unix-stream"]
+
+[[example]]
+name = "unix-stream-server"
+required-features = ["unix-stream"]
+
+[[example]]
+name = "unix-seqpacket-client"
+required-features = ["unix-seqpacket"]
+
+[[example]]
+name = "unix-seqpacket-server"
+required-features = ["unix-seqpacket"]
 
 [package.metadata.docs.rs]
 features = ["macros", "tcp", "unix-stream", "unix-seqpacket"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ publish = ["crates-io"]
 keywords = ["rpc", "shared-memory"]
 categories = ["asynchronous", "network-programming"]
 
-rust-version = "1.65"
-edition = "2021"
+rust-version = "1.85"
+edition = "2024"
 
 [features]
 macros = ["fizyr-rpc-macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,12 @@ edition = "2021"
 [features]
 macros = ["fizyr-rpc-macros"]
 tcp = ["tokio/net"]
-unix-seqpacket = ["tokio-seqpacket"]
+unix-seqpacket = ["tokio-seqpacket", "memfile"]
 unix-stream = ["tokio/net"]
 
 [dependencies]
 filedesc = { version = "0.6.1" }
+memfile = { version = "0.3.0", optional = true }
 tokio = { version = "1.32.0", features = ["rt", "sync"] }
 tokio-seqpacket = { version = "0.7.0", optional = true }
 fizyr-rpc-macros = { version = "0.8.0", path = "macros", optional = true }
@@ -36,7 +37,6 @@ assert2 = "0.3.11"
 clap = { version = "4.4.4", features = ["derive"] }
 tokio = { version = "1.32.0", features = ["macros"] }
 fizyr-rpc = { path = ".", features = ["unix-seqpacket", "unix-stream", "tcp"] }
-memfile = "0.3.0"
 
 [package.metadata.docs.rs]
 features = ["macros", "tcp", "unix-stream", "unix-seqpacket"]

--- a/macros-tests/Cargo.toml
+++ b/macros-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "macros-tests"
 version = "0.0.0"
-edition = "2018"
+edition = "2024"
 publish = []
 
 [dependencies]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,10 +11,10 @@ license = "BSD-2-Clause OR Apache-2.0"
 repository = "https://github.com/fizyr/fizyr-rpc"
 publish = ["crates-io"]
 
-edition = "2021"
+edition = "2024"
 
 [lib]
-proc_macro = true
+proc-macro = true
 
 [dependencies]
 syn = { version = "2.0.37", default-features = false, features = ["derive", "parsing", "printing", "proc-macro"] }

--- a/macros/src/interface/parse.rs
+++ b/macros/src/interface/parse.rs
@@ -119,10 +119,6 @@ pub mod cooked {
 		/// The doc comments of the message.
 		fn doc(&self) -> &[WithSpan<String>];
 
-		/// Check if the message should be hidden from generated documentation.
-		#[allow(dead_code)] // Used by generated code paths.
-		fn hidden(&self) -> Option<Hidden>;
-
 		/// The type of the message body.
 		fn body_type(&self) -> &syn::Type;
 	}
@@ -461,10 +457,6 @@ pub mod cooked {
 			self.doc()
 		}
 
-		fn hidden(&self) -> Option<Hidden> {
-			self.hidden
-		}
-
 		fn body_type(&self) -> &syn::Type {
 			self.body_type()
 		}
@@ -481,10 +473,6 @@ pub mod cooked {
 
 		fn doc(&self) -> &[WithSpan<String>] {
 			self.doc()
-		}
-
-		fn hidden(&self) -> Option<Hidden> {
-			self.hidden
 		}
 
 		fn body_type(&self) -> &syn::Type {

--- a/macros/src/interface/parse.rs
+++ b/macros/src/interface/parse.rs
@@ -120,6 +120,7 @@ pub mod cooked {
 		fn doc(&self) -> &[WithSpan<String>];
 
 		/// Check if the message should be hidden from generated documentation.
+		#[allow(dead_code)] // Used by generated code paths.
 		fn hidden(&self) -> Option<Hidden>;
 
 		/// The type of the message body.
@@ -538,6 +539,7 @@ pub mod raw {
 		pub body: MaybeServiceBody,
 	}
 
+	#[allow(dead_code)] // Used by generated code paths.
 	pub enum MaybeServiceBody {
 		NoBody(syn::token::Comma),
 		Body(ServiceBody, Option<syn::token::Comma>),
@@ -557,6 +559,7 @@ pub mod raw {
 		pub body_type: Box<syn::Type>,
 	}
 
+	#[allow(dead_code)] // Used by generated code paths.
 	pub enum UpdateKind {
 		RequestUpdate(keyword::request_update),
 		ResponseUpdate(keyword::response_update),

--- a/macros/src/interface/parse.rs
+++ b/macros/src/interface/parse.rs
@@ -527,9 +527,10 @@ pub mod raw {
 		pub body: MaybeServiceBody,
 	}
 
-	#[allow(dead_code)]
 	pub enum MaybeServiceBody {
+		#[allow(dead_code, reason = "Preserve parsed syntax in the struct")]
 		NoBody(syn::token::Comma),
+		#[allow(dead_code, reason = "Preserve parsed syntax in the struct")]
 		Body(ServiceBody, Option<syn::token::Comma>),
 	}
 
@@ -547,9 +548,10 @@ pub mod raw {
 		pub body_type: Box<syn::Type>,
 	}
 
-	#[allow(dead_code)]
 	pub enum UpdateKind {
+		#[allow(dead_code, reason = "Preserve parsed syntax in the struct")]
 		RequestUpdate(keyword::request_update),
+		#[allow(dead_code, reason = "Preserve parsed syntax in the struct")]
 		ResponseUpdate(keyword::response_update),
 	}
 

--- a/macros/src/interface/parse.rs
+++ b/macros/src/interface/parse.rs
@@ -527,7 +527,7 @@ pub mod raw {
 		pub body: MaybeServiceBody,
 	}
 
-	#[allow(dead_code)] // Used by generated code paths.
+	#[allow(dead_code)]
 	pub enum MaybeServiceBody {
 		NoBody(syn::token::Comma),
 		Body(ServiceBody, Option<syn::token::Comma>),
@@ -547,7 +547,7 @@ pub mod raw {
 		pub body_type: Box<syn::Type>,
 	}
 
-	#[allow(dead_code)] // Used by generated code paths.
+	#[allow(dead_code)]
 	pub enum UpdateKind {
 		RequestUpdate(keyword::request_update),
 		ResponseUpdate(keyword::response_update),

--- a/src/error.rs
+++ b/src/error.rs
@@ -375,7 +375,7 @@ pub(crate) mod private {
 	}
 
 	/// Check if a message size is large enough to contain a valid message.
-	#[allow(dead_code)] // not used when all transports are disabled.
+	#[allow(dead_code, reason = "Only referenced from unix-seqpacket transport")]
 	pub fn check_message_too_short(message_len: usize) -> Result<(), InnerError> {
 		if message_len >= crate::HEADER_LEN as usize {
 			Ok(())
@@ -385,7 +385,7 @@ pub(crate) mod private {
 	}
 
 	/// Check if a payload length is small enough to fit in a message body.
-	#[allow(dead_code)] // not used when all transports are disabled.
+	#[allow(dead_code, reason = "Only referenced from unix-seqpacket transport")]
 	pub fn check_payload_too_large(body_len: usize, max_len: usize) -> Result<(), InnerError> {
 		if body_len <= max_len {
 			Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -385,6 +385,7 @@ pub(crate) mod private {
 	}
 
 	/// Check if a payload length is small enough to fit in a message body.
+	#[allow(dead_code)] // not used when all transports are disabled.
 	pub fn check_payload_too_large(body_len: usize, max_len: usize) -> Result<(), InnerError> {
 		if body_len <= max_len {
 			Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,10 @@
 //! # Example
 //!
 //! ```no_run
+//! # #[cfg(feature = "tcp")]
+//! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
 //! use fizyr_rpc::{TcpPeer, StreamConfig};
 //!
-//! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
 //! let (peer, info) = TcpPeer::connect("localhost:1337", StreamConfig::default()).await?;
 //! eprintln!("Connected to: {}", info.remote_address());
 //! let mut request = peer.send_request(1, &b"Hello World!"[..]).await?;
@@ -74,6 +75,9 @@
 //! eprintln!("Received response: {}", body);
 //! # Ok(())
 //! # }
+//! #
+//! # #[cfg(not(feature = "tcp"))]
+//! # fn foo() {}
 //! ```
 
 #![warn(missing_docs)]

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -504,7 +504,7 @@ impl<Body> From<ProcessReceivedMessage<Body>> for Command<Body> {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "unix-stream"))]
 mod test {
 	use super::*;
 	use assert2::assert;

--- a/src/peer_handle.rs
+++ b/src/peer_handle.rs
@@ -240,7 +240,7 @@ impl<Body> std::fmt::Debug for PeerWriteHandle<Body> {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "unix-seqpacket"))]
 mod test {
 	use fizyr_rpc::UnixSeqpacketTransport;
 

--- a/src/peer_handle.rs
+++ b/src/peer_handle.rs
@@ -242,24 +242,25 @@ impl<Body> std::fmt::Debug for PeerWriteHandle<Body> {
 
 #[cfg(all(test, feature = "unix-seqpacket"))]
 mod test {
-	use fizyr_rpc::UnixSeqpacketTransport;
+	use crate::UnixSeqpacketTransport;
 
 	use assert2::assert;
 	use assert2::let_assert;
+	use crate::UnixSeqpacketPeer;
 	use tokio_seqpacket::UnixSeqpacket;
 
 	#[tokio::test]
 	async fn test_same_peer() {
 		let_assert!(Ok((peer_a, peer_b)) = UnixSeqpacket::pair());
 		let transport_a = UnixSeqpacketTransport::new(peer_a, Default::default());
-		let peer_handle = fizyr_rpc::UnixSeqpacketPeer::spawn(transport_a);
+		let peer_handle = UnixSeqpacketPeer::spawn(transport_a);
 
 		let (_, write_handle_a) = peer_handle.split();
 		let duplicate = write_handle_a.clone();
 		assert!(write_handle_a.same_peer(&duplicate));
 
 		let transport_b = UnixSeqpacketTransport::new(peer_b, Default::default());
-		let peer_handle = fizyr_rpc::UnixSeqpacketPeer::spawn(transport_b);
+		let peer_handle = UnixSeqpacketPeer::spawn(transport_b);
 		let (_, write_handle_b) = peer_handle.split();
 		assert!(!write_handle_a.same_peer(&write_handle_b));
 	}

--- a/src/request.rs
+++ b/src/request.rs
@@ -402,7 +402,7 @@ impl<Body> Clone for ReceivedRequestWriteHandle<Body> {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "unix-stream"))]
 mod test {
 	use super::*;
 	use crate::{Peer, UnixStreamTransport};

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -77,7 +77,7 @@ impl TransportError {
 	/// Create a new fatal transport error from an inner error.
 	///
 	/// After a transport returns a fatal error, the transport should not be used anymore.
-	#[allow(dead_code)] // Used by transport-specific code.
+	#[allow(dead_code, reason = "Used by transport-specific code")]
 	fn new_fatal(inner: impl Into<Error>) -> Self {
 		Self {
 			inner: inner.into(),
@@ -88,7 +88,7 @@ impl TransportError {
 	/// Create a new non-fatal transport error from an inner error.
 	///
 	/// A transport may still be used after returning a non-fatal error.
-	#[allow(dead_code)] // Used by transport-specific code.
+	#[allow(dead_code, reason = "Used by transport-specific code")]
 	fn new_non_fatal(inner: impl Into<Error>) -> Self {
 		Self {
 			inner: inner.into(),

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -77,6 +77,7 @@ impl TransportError {
 	/// Create a new fatal transport error from an inner error.
 	///
 	/// After a transport returns a fatal error, the transport should not be used anymore.
+	#[allow(dead_code)] // Used by transport-specific code.
 	fn new_fatal(inner: impl Into<Error>) -> Self {
 		Self {
 			inner: inner.into(),
@@ -87,6 +88,7 @@ impl TransportError {
 	/// Create a new non-fatal transport error from an inner error.
 	///
 	/// A transport may still be used after returning a non-fatal error.
+	#[allow(dead_code)] // Used by transport-specific code.
 	fn new_non_fatal(inner: impl Into<Error>) -> Self {
 		Self {
 			inner: inner.into(),
@@ -135,7 +137,7 @@ pub trait TransportReadHalf: Send + Unpin {
 	fn poll_read_msg(self: Pin<&mut Self>, context: &mut Context) -> Poll<Result<Message<Self::Body>, TransportError>>;
 
 	/// Asynchronously read a complete message from the transport.
-	fn read_msg(&mut self) -> ReadMsg<Self>
+	fn read_msg(&mut self) -> ReadMsg<'_, Self>
 	where
 		Self: Unpin,
 	{
@@ -164,7 +166,7 @@ pub trait TransportWriteHalf: Send + Unpin {
 	fn poll_write_msg(self: Pin<&mut Self>, context: &mut Context, header: &MessageHeader, body: &Self::Body) -> Poll<Result<(), TransportError>>;
 
 	/// Asynchronously write a message to the transport.
-	fn write_msg<'c>(&'c mut self, header: &'c MessageHeader, body: &'c Self::Body) -> WriteMsg<Self> {
+	fn write_msg<'c>(&'c mut self, header: &'c MessageHeader, body: &'c Self::Body) -> WriteMsg<'c, Self> {
 		WriteMsg { inner: self, header, body }
 	}
 }

--- a/src/transport/stream/mod.rs
+++ b/src/transport/stream/mod.rs
@@ -4,7 +4,7 @@ mod transport;
 
 pub use body::StreamBody;
 pub use config::StreamConfig;
-#[allow(unused_imports)] // Public re-exports, not used when only the core transport traits are enabled.
+#[allow(unused_imports, reason = "Used by transport-specific code")]
 pub use transport::{StreamReadHalf, StreamTransport, StreamWriteHalf};
 
 /// Information about the remote peer of a Unix stream.

--- a/src/transport/stream/mod.rs
+++ b/src/transport/stream/mod.rs
@@ -4,6 +4,7 @@ mod transport;
 
 pub use body::StreamBody;
 pub use config::StreamConfig;
+#[allow(unused_imports)] // Public re-exports, not used when only the core transport traits are enabled.
 pub use transport::{StreamReadHalf, StreamTransport, StreamWriteHalf};
 
 /// Information about the remote peer of a Unix stream.

--- a/src/transport/stream/mod.rs
+++ b/src/transport/stream/mod.rs
@@ -52,7 +52,7 @@ mod impl_unix_stream {
 		type ReadHalf<'a> = StreamReadHalf<tokio::net::unix::ReadHalf<'a>>;
 		type WriteHalf<'a> = StreamWriteHalf<tokio::net::unix::WriteHalf<'a>>;
 
-		fn split(&mut self) -> (StreamReadHalf<tokio::net::unix::ReadHalf>, StreamWriteHalf<tokio::net::unix::WriteHalf>) {
+		fn split(&mut self) -> (StreamReadHalf<tokio::net::unix::ReadHalf<'_>>, StreamWriteHalf<tokio::net::unix::WriteHalf<'_>>) {
 			let (read_half, write_half) = self.stream.split();
 			let read_half = StreamReadHalf::new(read_half, self.config.max_body_len_read, self.config.endian);
 			let write_half = StreamWriteHalf::new(write_half, self.config.max_body_len_write, self.config.endian);
@@ -154,7 +154,7 @@ mod impl_tcp {
 		type ReadHalf<'a> = StreamReadHalf<tokio::net::tcp::ReadHalf<'a>>;
 		type WriteHalf<'a> = StreamWriteHalf<tokio::net::tcp::WriteHalf<'a>>;
 
-		fn split(&mut self) -> (StreamReadHalf<tokio::net::tcp::ReadHalf>, StreamWriteHalf<tokio::net::tcp::WriteHalf>) {
+		fn split(&mut self) -> (StreamReadHalf<tokio::net::tcp::ReadHalf<'_>>, StreamWriteHalf<tokio::net::tcp::WriteHalf<'_>>) {
 			let (read_half, write_half) = self.stream.split();
 			let read_half = StreamReadHalf::new(read_half, self.config.max_body_len_read, self.config.endian);
 			let write_half = StreamWriteHalf::new(write_half, self.config.max_body_len_write, self.config.endian);

--- a/src/transport/stream/mod.rs
+++ b/src/transport/stream/mod.rs
@@ -204,7 +204,7 @@ mod impl_tcp {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "unix-stream"))]
 mod test {
 	use super::*;
 	use assert2::assert;

--- a/src/transport/stream/transport.rs
+++ b/src/transport/stream/transport.rs
@@ -12,7 +12,7 @@ use crate::{Message, MessageHeader};
 const FRAMED_HEADER_LEN: usize = 4 + crate::HEADER_LEN as usize;
 
 /// Transport layer for byte-stream sockets.
-#[allow(dead_code)] // Fields are not used when transports are disabled.
+#[allow(dead_code, reason = "Used by transport-specific code")]
 pub struct StreamTransport<Stream> {
 	/// The stream to use for sending/receiving messages.
 	pub(super) stream: Stream,
@@ -22,7 +22,7 @@ pub struct StreamTransport<Stream> {
 }
 
 /// The read half of a [`StreamTransport`].
-#[allow(dead_code)] // Not used when transports are disabled.
+#[allow(dead_code, reason = "Used by transport-specific code")]
 pub struct StreamReadHalf<ReadStream> {
 	/// The read half of the underlying stream.
 	pub(super) stream: ReadStream,
@@ -47,7 +47,7 @@ pub struct StreamReadHalf<ReadStream> {
 }
 
 /// The write half of a [`StreamTransport`].
-#[allow(dead_code)] // Not used when transports are disabled.
+#[allow(dead_code, reason = "Used by transport-specific code")]
 pub struct StreamWriteHalf<WriteStream> {
 	/// The write half of the underlying stream.
 	pub(super) stream: WriteStream,
@@ -96,7 +96,7 @@ where
 }
 
 impl<ReadStream> StreamReadHalf<ReadStream> {
-	#[allow(dead_code)] // Not used when transports are disabled.
+	#[allow(dead_code, reason = "Used by transport-specific code")]
 	pub(super) fn new(stream: ReadStream, max_body_len: u32, endian: Endian) -> Self {
 		Self {
 			stream,
@@ -110,20 +110,20 @@ impl<ReadStream> StreamReadHalf<ReadStream> {
 	}
 
 	/// Get direct access to the underlying stream.
-	#[allow(dead_code)] // Not used when transports are disabled.
+	#[allow(dead_code, reason = "Used by transport-specific code")]
 	pub fn stream(&self) -> &ReadStream {
 		&self.stream
 	}
 
 	/// Get direct mutable access to the underlying stream.
-	#[allow(dead_code)] // Not used when transports are disabled.
+	#[allow(dead_code, reason = "Used by transport-specific code")]
 	pub fn stream_mut(&mut self) -> &ReadStream {
 		&mut self.stream
 	}
 }
 
 impl<WriteStream> StreamWriteHalf<WriteStream> {
-	#[allow(dead_code)] // Not used when transports are disabled.
+	#[allow(dead_code, reason = "Used by transport-specific code")]
 	pub(super) fn new(stream: WriteStream, max_body_len: u32, endian: Endian) -> Self {
 		Self {
 			stream,
@@ -135,20 +135,20 @@ impl<WriteStream> StreamWriteHalf<WriteStream> {
 	}
 
 	/// Get direct access to the underlying stream.
-	#[allow(dead_code)] // Not used when transports are disabled.
+	#[allow(dead_code, reason = "Used by transport-specific code")]
 	pub fn stream(&self) -> &WriteStream {
 		&self.stream
 	}
 
 	/// Get direct mutable access to the underlying stream.
-	#[allow(dead_code)] // Not used when transports are disabled.
+	#[allow(dead_code, reason = "Used by transport-specific code")]
 	pub fn stream_mut(&mut self) -> &WriteStream {
 		&mut self.stream
 	}
 }
 
 /// Wrapper around [`AsyncRead::poll_read`] that turns zero-sized reads into ConnectionAborted errors.
-#[allow(dead_code)] // Used by transport-specific implementations.
+#[allow(dead_code, reason = "Used by transport-specific code")]
 fn poll_read<R: AsyncRead>(stream: Pin<&mut R>, context: &mut Context, buf: &mut [u8]) -> Poll<std::io::Result<usize>> {
 	let mut buf = tokio::io::ReadBuf::new(buf);
 	ready!(stream.poll_read(context, &mut buf))?;

--- a/src/transport/stream/transport.rs
+++ b/src/transport/stream/transport.rs
@@ -148,6 +148,7 @@ impl<WriteStream> StreamWriteHalf<WriteStream> {
 }
 
 /// Wrapper around [`AsyncRead::poll_read`] that turns zero-sized reads into ConnectionAborted errors.
+#[allow(dead_code)] // Used by transport-specific implementations.
 fn poll_read<R: AsyncRead>(stream: Pin<&mut R>, context: &mut Context, buf: &mut [u8]) -> Poll<std::io::Result<usize>> {
 	let mut buf = tokio::io::ReadBuf::new(buf);
 	ready!(stream.poll_read(context, &mut buf))?;

--- a/src/transport/unix/mod.rs
+++ b/src/transport/unix/mod.rs
@@ -116,7 +116,7 @@ mod impl_unix_seqpacket {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "unix-seqpacket"))]
 mod test {
 	use assert2::assert;
 	use assert2::let_assert;

--- a/src/transport/unix/mod.rs
+++ b/src/transport/unix/mod.rs
@@ -4,6 +4,7 @@ mod transport;
 
 pub use body::UnixBody;
 pub use config::UnixConfig;
+#[allow(unused_imports)] // Public re-exports, not used when only the core transport traits are enabled.
 pub use transport::{UnixReadHalf, UnixTransport, UnixWriteHalf};
 
 /// Information about the remote peer of a Unix stream.

--- a/src/transport/unix/mod.rs
+++ b/src/transport/unix/mod.rs
@@ -4,7 +4,7 @@ mod transport;
 
 pub use body::UnixBody;
 pub use config::UnixConfig;
-#[allow(unused_imports)] // Public re-exports, not used when only the core transport traits are enabled.
+#[allow(unused_imports, reason = "Used by transport-specific code")]
 pub use transport::{UnixReadHalf, UnixTransport, UnixWriteHalf};
 
 /// Information about the remote peer of a Unix stream.

--- a/src/util/accept.rs
+++ b/src/util/accept.rs
@@ -16,7 +16,7 @@ pub trait Listener {
 	fn poll_accept(self: Pin<&mut Self>, context: &mut Context) -> Poll<std::io::Result<(Self::Connection, Self::Address)>>;
 
 	/// Asynchronously accept a new connection.
-	fn accept(&mut self) -> Accept<Self>
+	fn accept(&mut self) -> Accept<'_, Self>
 	where
 		Self: Unpin,
 	{


### PR DESCRIPTION
This PR improves the feature gating such that it compiles and runs on macOS (and presumably Windows too). One issue I had was that `memfile` was unconditionally added as a dependency, even though it was only used in a test. I "fixed" it by making it feature-gated behind the `unix-seqpacket` feature. Ideally it would be a `dev-dependency` instead, but then I can't feature gate it I believe.

This PR also fixes some clippy warnings and updates `edition` to `2024`.